### PR TITLE
feat: add errors helpers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 ### Description
 
-<!-- Briefly describe what this PR does -->
+<!-- Required: One-line summary of what the PR is about -->
 
 ### Type of Change
 
-<!-- Check the relevant option -->
+<!-- Required: Check the relevant option, keep unselected ones -->
 
 - [ ] 🐛 Bug fix
 - [ ] ✨ New feature
@@ -13,16 +13,15 @@
 - [ ] ♻️ Refactoring
 - [ ] ⚡ Performance
 - [ ] ✅ Tests
-- [ ] 🔐 Security
 - [ ] 🔧 Build/CI
 
-### Related Issue
+### Related Issues
 
-<!-- Link related issues: Fixes #123, Closes #456 -->
+<!-- Optional: List of links to related issues: Fixes #123, Closes #456 -->
 
 ### Changes
 
-<!-- List key changes -->
+<!-- Optional: List of one-line key changes -->
 
 ### Checklist
 
@@ -31,6 +30,6 @@
 - [ ] I have commented on my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.
 
-### Notes
+#### Notes
 
 <!-- Optional: Add additional context -->

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Go standard library extension, adding the missing parts used in the foomo ecosys
 
 ## Features
 
+- **errors** — Variadic match helpers (`AsAny`, `IsAny`) wrapping `errors.As` / `errors.Is`
 - **fmt** — Template string formatting with `%{.key}` syntax
 - **net** — Free port allocation and TCP connection wait helpers (`FreePort`, `FreePorts`, `WaitFor`, `WaitForFreePort`)
 - **options** — Generic functional options pattern (`Option`, `OptionE`, `Builder`, `BuilderE`)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -26,6 +26,7 @@ export default defineConfig({
 			{
 				text: 'Packages',
 				items: [
+					{ text: 'errors', link: '/errors' },
 					{ text: 'fmt', link: '/fmt' },
 					{ text: 'net', link: '/net' },
 					{ text: 'option', link: '/option' },

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,52 @@
+# errors
+
+Helpers extending the standard `errors` package.
+
+## Import
+
+```go
+import errorsx "github.com/foomo/go/errors"
+```
+
+## API
+
+### AsAny
+
+```go
+func AsAny(err error, targets ...any) bool
+```
+
+Reports whether `err` matches any of the targets via `errors.As`. Each target must be a non-nil pointer to either a type that implements `error`, or to any interface type.
+
+### IsAny
+
+```go
+func IsAny(err error, targets ...error) bool
+```
+
+Reports whether `err` matches any of the targets via `errors.Is`.
+
+## Examples
+
+### AsAny
+
+```go
+var (
+	pathErr *fs.PathError
+	numErr  *strconv.NumError
+)
+
+_, err := os.Open("/nonexistent/path")
+if errorsx.AsAny(err, &numErr, &pathErr) {
+	// err unwrapped into one of the targets
+}
+```
+
+### IsAny
+
+```go
+err := fmt.Errorf("wrapped: %w", io.EOF)
+if errorsx.IsAny(err, context.Canceled, io.EOF) {
+	// err matches one of the sentinels
+}
+```

--- a/errors/asany.go
+++ b/errors/asany.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"errors"
+)
+
+// AsAny reports whether err matches any of the targets via errors.As.
+func AsAny(err error, targets ...any) bool {
+	for _, target := range targets {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/errors/asany_test.go
+++ b/errors/asany_test.go
@@ -1,0 +1,21 @@
+package errors_test
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+
+	pkgerrors "github.com/foomo/go/errors"
+)
+
+func ExampleAsAny() {
+	var (
+		pathErr *fs.PathError
+		numErr  *strconv.NumError
+	)
+
+	_, err := os.Open("/nonexistent/path/for/example")
+	fmt.Println(pkgerrors.AsAny(err, &numErr, &pathErr))
+	// Output: true
+}

--- a/errors/asanytype.go
+++ b/errors/asanytype.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"errors"
+)
+
+// AsAnyType reports whether err matches any of the targets via errors.As.
+func AsAnyType(err error, targets ...any) bool {
+	for _, target := range targets {
+		if errors.As(err, &target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/errors/asanytype_test.go
+++ b/errors/asanytype_test.go
@@ -1,0 +1,16 @@
+package errors_test
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+
+	pkgerrors "github.com/foomo/go/errors"
+)
+
+func ExampleAsAnyType() {
+	_, err := os.Open("/nonexistent/path/for/example")
+	fmt.Println(pkgerrors.AsAnyType(err, &fs.PathError{}, &strconv.NumError{}))
+	// Output: true
+}

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors provides helpers extending the standard errors package.
+package errors

--- a/errors/isany.go
+++ b/errors/isany.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"errors"
+)
+
+// IsAny reports whether err matches any of the targets via errors.Is.
+func IsAny(err error, targets ...error) bool {
+	for _, target := range targets {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/errors/isany_test.go
+++ b/errors/isany_test.go
@@ -1,0 +1,15 @@
+package errors_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	pkgerrors "github.com/foomo/go/errors"
+)
+
+func ExampleIsAny() {
+	err := fmt.Errorf("wrapped: %w", io.EOF)
+	fmt.Println(pkgerrors.IsAny(err, context.Canceled, io.EOF))
+	// Output: true
+}

--- a/errors/main_test.go
+++ b/errors/main_test.go
@@ -1,0 +1,11 @@
+package errors_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
### Description

Add `errors` helpers package with variadic `errors.As` / `errors.Is` match functions, following repo conventions.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- New `errors/` package: `AsAny`, `AsAnyType`, `IsAny` wrapping `errors.As` / `errors.Is` with variadic target lists
- Package layout mirrors `slices/`: `doc.go`, paired `*_test.go` with `Example*` functions, `main_test.go` with `goleak.VerifyTestMain`
- Docs: `docs/errors.md` + sidebar entry in `docs/.vitepress/config.mts`; README package list updated
- PR template tweaks

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.