### PR TITLE
feat(time): add parsetime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,49 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/dependabot-2.0.json
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 updates:
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 1
-    commit-message: { prefix: 'chore(deps)' }
+    commit-message: { prefix: sec(gha) }
+    open-pull-requests-limit: 0
     directory: '/'
     schedule:
       interval: daily
+      timezone: Europe/Berlin
+    groups:
+      security:
+        applies-to: security-updates
+        group-by: dependency-name
+        patterns: ['*']
     cooldown:
       default-days: 3
 
   - package-ecosystem: gomod
-    open-pull-requests-limit: 1
-    commit-message: { prefix: 'sec(deps)' }
-    directories: [ '**/*' ]
+    commit-message: { prefix: sec(gomod) }
+    open-pull-requests-limit: 0
+    directory: '/'
     schedule:
       interval: daily
+      timezone: Europe/Berlin
     groups:
       security:
         applies-to: security-updates
-        update-types: [ minor, patch ]
-    ignore:
-      - dependency-name: '*'
-        update-types: [ 'version-update:semver-major' ]
+        group-by: dependency-name
+        patterns: ['*']
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: bun
+    commit-message: { prefix: sec(bun) }
+    open-pull-requests-limit: 0
+    directory: '/docs'
+    schedule:
+      interval: daily
+      timezone: Europe/Berlin
+    groups:
+      security:
+        applies-to: security-updates
+        group-by: dependency-name
+        patterns: ['*']
     cooldown:
       default-days: 3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # https://github.com/actions/checkout/releases
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,12 @@
+#:schema https://mise.jdx.dev/schema/mise.json
+
+[settings]
+minimum_release_age = "3d"
+
 [tools]
 # https://mise-tools.jdx.dev/tools/bun
 bun = "1.3.14"
-# https://mise-tools.jdx.dev/tools/lefthook
-lefthook = "2.1.9"
 # https://mise-tools.jdx.dev/tools/golangci-lint
 golangci-lint = "2.12.2"
+# https://mise-tools.jdx.dev/tools/lefthook
+lefthook = "2.1.9"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Go standard library extension, adding the missing parts used in the foomo ecosys
 - **slog** — Test-friendly `slog.Handler` that writes to `testing.TB` output
 - **strings** — Case conversions, padding, validation, prefix/suffix matching, and composition
 - **testing** — Tag-based test filtering via `GO_TEST_TAGS`, crypto key helpers, `ExampleTB`
-- **time** — Context-aware `Sleep` and polling `WaitFor`
+- **time** — Context-aware `Sleep` and polling `WaitFor`; `ParseDuration` (adds `d`/`w` units)
 - **types** — Common interface contracts (`Closer`, `Starter`, `Stopper`, …) with function adapters and `As<X>` helpers
 
 ## How to Contribute

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,6 +1,6 @@
 # time
 
-Context-aware time utilities.
+Context-aware time utilities and duration parsing.
 
 ## Import
 
@@ -25,6 +25,14 @@ func WaitFor(ctx context.Context, fn func(context.Context) (bool, error), timeou
 ```
 
 Polls `fn` until it returns `true`, returns an error, or the timeout deadline elapses. Sleeps `interval` between attempts using context-aware `Sleep`, so a canceled context aborts the wait. Returns `context.DeadlineExceeded` if the deadline is reached without success.
+
+### ParseDuration
+
+```go
+func ParseDuration(s string) (time.Duration, error)
+```
+
+Parses a duration string like `time.ParseDuration`, but also accepts the `d` (day, 24h) and `w` (week, 168h) units. Valid units: `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`, `d`, `w`.
 
 ## Examples
 
@@ -67,4 +75,18 @@ err := timex.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 if err != nil {
 	log.Fatal(err)
 }
+```
+
+### ParseDuration
+
+```go
+for _, s := range []string{"2w", "5d", "1w2d3h"} {
+	d, _ := timex.ParseDuration(s)
+	fmt.Printf("%s = %s\n", s, d)
+}
+
+// Output:
+// 2w = 336h0m0s
+// 5d = 120h0m0s
+// 1w2d3h = 219h0m0s
 ```

--- a/time/main_test.go
+++ b/time/main_test.go
@@ -1,0 +1,11 @@
+package time_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/time/parseduration.go
+++ b/time/parseduration.go
@@ -1,0 +1,213 @@
+package time
+
+import (
+	"errors"
+	"time"
+)
+
+// unitMap maps duration unit suffixes to their nanosecond value. It extends the
+// standard library's set with "d" (day, 24h) and "w" (week, 168h).
+var unitMap = map[string]int64{
+	"ns": int64(time.Nanosecond),
+	"us": int64(time.Microsecond),
+	"µs": int64(time.Microsecond), // U+00B5 = micro symbol
+	"μs": int64(time.Microsecond), // U+03BC = Greek letter mu
+	"ms": int64(time.Millisecond),
+	"s":  int64(time.Second),
+	"m":  int64(time.Minute),
+	"h":  int64(time.Hour),
+	"d":  int64(time.Hour) * 24,
+	"w":  int64(time.Hour) * 168,
+}
+
+// ParseDuration parses a duration string.
+// A duration string is a possibly signed sequence of
+// decimal numbers, each with optional fraction and a unit suffix,
+// such as "300ms", "-1.5h" or "2h45m".
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h", "d", "w".
+//
+// Unlike the standard library's time.ParseDuration, this also accepts the
+// "d" (day, 24h) and "w" (week, 168h) units.
+func ParseDuration(s string) (time.Duration, error) {
+	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
+	orig := s
+
+	var d int64
+
+	neg := false
+
+	// Consume [-+]?
+	if s != "" {
+		c := s[0]
+		if c == '-' || c == '+' {
+			neg = c == '-'
+			s = s[1:]
+		}
+	}
+	// Special case: if all that is left is "0", this is zero.
+	if s == "0" {
+		return 0, nil
+	}
+
+	if s == "" {
+		return 0, errors.New("time: invalid duration " + quote(orig))
+	}
+
+	for s != "" {
+		var (
+			v, f  int64       // integers before, after decimal point
+			scale float64 = 1 // value = v + f/scale
+		)
+
+		var err error
+
+		// The next character must be [0-9.]
+		if s[0] != '.' && ('0' > s[0] || s[0] > '9') {
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+		// Consume [0-9]*
+		pl := len(s)
+
+		v, s, err = leadingInt(s)
+		if err != nil {
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+
+		pre := pl != len(s) // whether we consumed anything before a period
+
+		// Consume (\.[0-9]*)?
+		post := false
+
+		if s != "" && s[0] == '.' {
+			s = s[1:]
+			pl := len(s)
+			f, scale, s = leadingFraction(s)
+			post = pl != len(s)
+		}
+
+		if !pre && !post {
+			// no digits (e.g. ".s" or "-.s")
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+
+		// Consume unit.
+		i := 0
+		for ; i < len(s); i++ {
+			c := s[i]
+			if c == '.' || '0' <= c && c <= '9' {
+				break
+			}
+		}
+
+		if i == 0 {
+			return 0, errors.New("time: missing unit in duration " + quote(orig))
+		}
+
+		u := s[:i]
+		s = s[i:]
+
+		unit, ok := unitMap[u]
+		if !ok {
+			return 0, errors.New("time: unknown unit " + quote(u) + " in duration " + quote(orig))
+		}
+
+		if v > (1<<63-1)/unit {
+			// overflow
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+
+		v *= unit
+		if f > 0 {
+			// float64 is needed to be nanosecond accurate for fractions of hours.
+			// v >= 0 && (f*unit/scale) <= 3.6e+12 (ns/h, h is the largest unit)
+			v += int64(float64(f) * (float64(unit) / scale))
+			if v < 0 {
+				// overflow
+				return 0, errors.New("time: invalid duration " + quote(orig))
+			}
+		}
+
+		d += v
+		if d < 0 {
+			// overflow
+			return 0, errors.New("time: invalid duration " + quote(orig))
+		}
+	}
+
+	if neg {
+		d = -d
+	}
+
+	return time.Duration(d), nil
+}
+
+func quote(s string) string {
+	return "\"" + s + "\""
+}
+
+var errLeadingInt = errors.New("time: bad [0-9]*") // never printed
+
+// leadingInt consumes the leading [0-9]* from s.
+func leadingInt(s string) (int64, string, error) {
+	var x int64
+
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+
+		if x > (1<<63-1)/10 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+
+		x = x*10 + int64(c) - '0'
+		if x < 0 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+	}
+
+	return x, s[i:], nil
+}
+
+// leadingFraction consumes the leading [0-9]* from s.
+// It is used only for fractions, so does not return an error on overflow,
+// it just stops accumulating precision.
+func leadingFraction(s string) (int64, float64, string) {
+	var x int64
+
+	scale := float64(1)
+	i := 0
+	overflow := false
+
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+
+		if overflow {
+			continue
+		}
+
+		if x > (1<<63-1)/10 {
+			// It's possible for overflow to give a positive number, so take care.
+			overflow = true
+			continue
+		}
+
+		y := x*10 + int64(c) - '0'
+		if y < 0 {
+			overflow = true
+			continue
+		}
+
+		x = y
+		scale *= 10
+	}
+
+	return x, scale, s[i:]
+}

--- a/time/parseduration_test.go
+++ b/time/parseduration_test.go
@@ -1,0 +1,60 @@
+package time_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	gotime "github.com/foomo/go/time"
+)
+
+func ExampleParseDuration() {
+	for _, s := range []string{"2w", "5d", "1w2d3h"} {
+		d, _ := gotime.ParseDuration(s)
+		fmt.Printf("%s = %s\n", s, d)
+	}
+
+	// Output:
+	// 2w = 336h0m0s
+	// 5d = 120h0m0s
+	// 1w2d3h = 219h0m0s
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"5d", 120 * time.Hour},
+		{"2w", 336 * time.Hour},
+		{"1.5d", 36 * time.Hour},
+		{"-2w", -336 * time.Hour},
+		{"1w2d3h4m5s", 168*time.Hour + 48*time.Hour + 3*time.Hour + 4*time.Minute + 5*time.Second},
+		{"2h45m", 2*time.Hour + 45*time.Minute},
+		{"300ms", 300 * time.Millisecond},
+		{"0", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := gotime.ParseDuration(tt.in)
+			if err != nil {
+				t.Fatalf("ParseDuration(%q) unexpected error: %v", tt.in, err)
+			}
+
+			if got != tt.want {
+				t.Errorf("ParseDuration(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDurationErrors(t *testing.T) {
+	for _, in := range []string{"", "10", "1x", ".s", "-"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := gotime.ParseDuration(in); err == nil {
+				t.Errorf("ParseDuration(%q) expected error, got nil", in)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Add `timex.ParseDuration` with extended `d`/`w` units, plus repo housekeeping (CI timeouts, dependabot, mise).

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- Add `time/parseduration.go` — `ParseDuration` parsing stdlib units plus `d` (day) and `w` (week)
- Add `time/parseduration_test.go` and goleak `main_test.go` entry
- Document in `docs/time.md` and `README.md`
- Add `timeout-minutes: 15` to `docs`, `release`, `test` workflows
- Rework `.github/dependabot.yml` — security-grouped updates, add `bun` ecosystem, `Europe/Berlin` schedule
- Pin mise schema + `minimum_release_age = "3d"` in `.mise.toml`

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.