### PR TITLE
fix(errors): nil error

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -9,4 +9,4 @@ bun = "1.3.14"
 # https://mise-tools.jdx.dev/tools/golangci-lint
 golangci-lint = "2.12.2"
 # https://mise-tools.jdx.dev/tools/lefthook
-lefthook = "2.1.9"
+lefthook = "2.1.10"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/foomo/go?style=flat-square)](https://goreportcard.com/report/github.com/foomo/go)
 [![GoDoc](https://img.shields.io/badge/GoDoc-✓-informational.svg?style=flat-square&logo=go)](https://godoc.org/github.com/foomo/go)
 [![Coverage](https://img.shields.io/codecov/c/github/foomo/go?style=flat-square&logo=github)](https://app.codecov.io/gh/foomo/go)
 [![GitHub Stars](https://img.shields.io/github/stars/foomo/go.svg?style=flat-square&logo=github)](https://github.com/foomo/go)

--- a/errors/asany_test.go
+++ b/errors/asany_test.go
@@ -1,10 +1,13 @@
 package errors_test
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"strconv"
+	"testing"
 
 	pkgerrors "github.com/foomo/go/errors"
 )
@@ -18,4 +21,89 @@ func ExampleAsAny() {
 	_, err := os.Open("/nonexistent/path/for/example")
 	fmt.Println(pkgerrors.AsAny(err, &numErr, &pathErr))
 	// Output: true
+}
+
+func TestAsAny(t *testing.T) {
+	pathErr := &fs.PathError{Op: "open", Path: "/x", Err: io.EOF}
+
+	tests := []struct {
+		name string
+		err  error
+		// targets returns fresh target pointers for each run.
+		targets func() []any
+		want    bool
+	}{
+		{
+			name:    "nil err",
+			err:     nil,
+			targets: func() []any { var p *fs.PathError; return []any{&p} },
+			want:    false,
+		},
+		{
+			name:    "no targets",
+			err:     pathErr,
+			targets: func() []any { return nil },
+			want:    false,
+		},
+		{
+			name:    "matches none",
+			err:     errors.New("plain"),
+			targets: func() []any { var p *fs.PathError; var n *strconv.NumError; return []any{&p, &n} },
+			want:    false,
+		},
+		{
+			name:    "match on first target",
+			err:     pathErr,
+			targets: func() []any { var p *fs.PathError; var n *strconv.NumError; return []any{&p, &n} },
+			want:    true,
+		},
+		{
+			name:    "match on last target",
+			err:     pathErr,
+			targets: func() []any { var n *strconv.NumError; var p *fs.PathError; return []any{&n, &p} },
+			want:    true,
+		},
+		{
+			name:    "wrapped error matches",
+			err:     fmt.Errorf("wrapped: %w", pathErr),
+			targets: func() []any { var p *fs.PathError; return []any{&p} },
+			want:    true,
+		},
+		{
+			name:    "deeply wrapped error matches",
+			err:     fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", pathErr)),
+			targets: func() []any { var p *fs.PathError; return []any{&p} },
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pkgerrors.AsAny(tt.err, tt.targets()...); got != tt.want {
+				t.Errorf("AsAny() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("populates matched target", func(t *testing.T) {
+		var (
+			numErr  *strconv.NumError
+			pathTgt *fs.PathError
+		)
+		if !pkgerrors.AsAny(pathErr, &numErr, &pathTgt) {
+			t.Fatal("AsAny() = false, want true")
+		}
+
+		if pathTgt == nil {
+			t.Fatal("matched target *fs.PathError was not populated")
+		}
+
+		if pathTgt.Path != "/x" {
+			t.Errorf("populated target Path = %q, want %q", pathTgt.Path, "/x")
+		}
+
+		if numErr != nil {
+			t.Error("non-matching target *strconv.NumError should remain nil")
+		}
+	})
 }

--- a/errors/asanytype.go
+++ b/errors/asanytype.go
@@ -2,12 +2,25 @@ package errors
 
 import (
 	"errors"
+	"reflect"
 )
 
-// AsAnyType reports whether err matches any of the targets via errors.As.
+// AsAnyType reports whether err matches the concrete type of any of the targets
+// via errors.As. Each target must be a pointer to the error type to match
+// (e.g. &fs.PathError{}); unlike AsAny, the caller need not declare target
+// variables and the matched value is discarded. nil targets are skipped.
 func AsAnyType(err error, targets ...any) bool {
+	if err == nil {
+		return false
+	}
+
 	for _, target := range targets {
-		if errors.As(err, &target) {
+		if target == nil {
+			continue
+		}
+		// reflect.New yields a **T so errors.As has a settable *T target.
+		ptr := reflect.New(reflect.TypeOf(target)).Interface()
+		if errors.As(err, ptr) {
 			return true
 		}
 	}

--- a/errors/asanytype_test.go
+++ b/errors/asanytype_test.go
@@ -1,10 +1,13 @@
 package errors_test
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"strconv"
+	"testing"
 
 	pkgerrors "github.com/foomo/go/errors"
 )
@@ -12,5 +15,91 @@ import (
 func ExampleAsAnyType() {
 	_, err := os.Open("/nonexistent/path/for/example")
 	fmt.Println(pkgerrors.AsAnyType(err, &fs.PathError{}, &strconv.NumError{}))
+
 	// Output: true
+}
+
+// customError is a distinct error type used to exercise type-based matching.
+type customError struct{ msg string }
+
+func (e *customError) Error() string { return e.msg }
+
+func TestAsAnyType(t *testing.T) {
+	pathErr := &fs.PathError{Op: "open", Path: "/x", Err: io.EOF}
+
+	tests := []struct {
+		name    string
+		err     error
+		targets []any
+		want    bool
+	}{
+		{
+			name:    "matching target type",
+			err:     pathErr,
+			targets: []any{&fs.PathError{}},
+			want:    true,
+		},
+		{
+			name:    "unrelated target type",
+			err:     pathErr,
+			targets: []any{&strconv.NumError{}},
+			want:    false, // would be true before the AsAnyType fix
+		},
+		{
+			name:    "nil err",
+			err:     nil,
+			targets: []any{&fs.PathError{}},
+			want:    false,
+		},
+		{
+			name:    "no targets",
+			err:     pathErr,
+			targets: nil,
+			want:    false,
+		},
+		{
+			name:    "match on first target",
+			err:     pathErr,
+			targets: []any{&fs.PathError{}, &strconv.NumError{}},
+			want:    true,
+		},
+		{
+			name:    "match on second target",
+			err:     pathErr,
+			targets: []any{&strconv.NumError{}, &fs.PathError{}},
+			want:    true,
+		},
+		{
+			name:    "matches none",
+			err:     errors.New("plain"),
+			targets: []any{&fs.PathError{}, &strconv.NumError{}},
+			want:    false,
+		},
+		{
+			name:    "wrapped error type match",
+			err:     fmt.Errorf("wrapped: %w", pathErr),
+			targets: []any{&strconv.NumError{}, &fs.PathError{}},
+			want:    true,
+		},
+		{
+			name:    "deeply wrapped custom error type match",
+			err:     fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &customError{msg: "boom"})),
+			targets: []any{&fs.PathError{}, &customError{}},
+			want:    true,
+		},
+		{
+			name:    "nil target skipped then match",
+			err:     pathErr,
+			targets: []any{nil, &fs.PathError{}},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pkgerrors.AsAnyType(tt.err, tt.targets...); got != tt.want {
+				t.Errorf("AsAnyType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/errors/isany_test.go
+++ b/errors/isany_test.go
@@ -2,8 +2,10 @@ package errors_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"testing"
 
 	pkgerrors "github.com/foomo/go/errors"
 )
@@ -12,4 +14,72 @@ func ExampleIsAny() {
 	err := fmt.Errorf("wrapped: %w", io.EOF)
 	fmt.Println(pkgerrors.IsAny(err, context.Canceled, io.EOF))
 	// Output: true
+}
+
+func TestIsAny(t *testing.T) {
+	sentinel := errors.New("sentinel")
+
+	tests := []struct {
+		name    string
+		err     error
+		targets []error
+		want    bool
+	}{
+		{
+			name:    "no targets",
+			err:     io.EOF,
+			targets: nil,
+			want:    false,
+		},
+		{
+			name:    "nil err and nil target match",
+			err:     nil,
+			targets: []error{nil},
+			want:    true, // errors.Is(nil, nil) == true
+		},
+		{
+			name:    "nil err with real target",
+			err:     nil,
+			targets: []error{io.EOF},
+			want:    false,
+		},
+		{
+			name:    "match on first target",
+			err:     io.EOF,
+			targets: []error{io.EOF, context.Canceled},
+			want:    true,
+		},
+		{
+			name:    "match on last target",
+			err:     context.Canceled,
+			targets: []error{io.EOF, sentinel, context.Canceled},
+			want:    true,
+		},
+		{
+			name:    "matches none",
+			err:     sentinel,
+			targets: []error{io.EOF, context.Canceled},
+			want:    false,
+		},
+		{
+			name:    "wrapped error matches",
+			err:     fmt.Errorf("wrapped: %w", io.EOF),
+			targets: []error{context.Canceled, io.EOF},
+			want:    true,
+		},
+		{
+			name:    "deeply wrapped error matches",
+			err:     fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", sentinel)),
+			targets: []error{io.EOF, sentinel},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pkgerrors.IsAny(tt.err, tt.targets...); got != tt.want {
+				t.Errorf("IsAny() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Description

Fix `errors.AsAnyType` matching any error type and add test coverage across the errors package.

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- Fix `AsAnyType` taking `&target` (a `*any`), which made `errors.As` match every error; now uses `reflect.New` to build a settable `*T` target per candidate type
- Guard `AsAnyType` against `nil` err and skip `nil` targets
- Add table-driven tests for `AsAny`, `AsAnyType`, and `IsAny` (nil, no-targets, first/last match, wrapped and deeply-wrapped errors, target population)
- Bump `lefthook` 2.1.9 → 2.1.10 in `.mise.toml`
- Remove Go Report Card badge from `README.md`

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.