### PR TITLE
feat(runtime) add callframe

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,6 +59,7 @@ linters:
     goconst:
       min-occurrences: 5
       ignore-tests: true
+      ignore-string-values: [ unknown ]
     # https://golangci-lint.run/docs/linters/configuration/#testifylint
     testifylint:
       disable: [ float-compare ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Go standard library extension, adding the missing parts used in the foomo ecosys
 - **net** — Free port allocation and TCP connection wait helpers (`FreePort`, `FreePorts`, `WaitFor`, `WaitForFreePort`)
 - **options** — Generic functional options pattern (`Option`, `OptionE`, `Builder`, `BuilderE`)
 - **os** — Typed `Getenv`/`MustGetenv` for scalars, slices, and maps with defaults; path `Expand` (`~/`, env vars)
-- **runtime** — Enriched caller introspection (`Caller`, `CallerFunc`, `StackTrace`) and panic recovery
+- **runtime** — Enriched caller introspection (`Caller`, `CallerFunc`, `CallFrame`, `StackTrace`), per-call-site memoisation (`Frame`, `Memo`), and panic recovery
 - **sec** — Safe path joining to prevent directory traversal (gosec G304)
 - **slices** — Generic slice utilities: `Filter`, `Map`, `GroupBy` (with error variants)
 - **slog** — Test-friendly `slog.Handler` that writes to `testing.TB` output

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -39,6 +39,42 @@ package.Function
   dir/file.go:42
 ```
 
+### CallFrame
+
+```go
+func CallFrame(skip int) Frame
+```
+
+Returns the call site `skip` levels above its own caller — `skip=0` is the function that called `CallFrame`, `skip=1` that function's caller, and so on. Symbolisation is memoised per program counter, so the steady-state cost is one `runtime.Callers` into a stack array plus a map load, with no allocation. Returns a zero `Frame` (see `Frame.Zero`) when the stack is unavailable.
+
+### Frame
+
+```go
+type Frame struct {
+	Pkg  string // full import path, e.g. "github.com/foomo/go/runtime"
+	Inst string // receiver type name for methods; empty for package-level funcs
+	Func string // function or method name, incl. suffixes like ".func1" or "-fm"
+	File string // absolute path as recorded at build time
+	Line int
+}
+
+func (f Frame) Name() string
+func (f Frame) Short() string
+func (f Frame) Zero() bool
+```
+
+Identifies a single call site. `Name` reassembles the qualified name (`pkg.Recv.Func`), suitable for the `code.function.name` attribute; the pointer-receiver marker is not preserved. `Short` renders the receiver-qualified name without the package path (`Recv.Func`). `Zero` reports whether the frame could not be resolved.
+
+### Memo
+
+```go
+type Memo[T any] struct { /* ... */ }
+
+func (mo *Memo[T]) Get(skip int, derive func(Frame) T) T
+```
+
+Caches a value of type `T` per call site, so per-site derived data — a span name, a preformatted attribute slice, a logger — is computed once for the life of the process rather than on every call. `Get` resolves the call site `skip` levels above its caller (`skip=0` is the function that called `Get`) and returns the memoised value, invoking `derive` at most once per site under normal conditions. `derive` must be pure and its result safe to share; values handed out by `Get` are shared across all calls from that site and must be treated as read-only. The zero value is ready to use and a `Memo` must not be copied after first use.
+
 ### Recover
 
 ```go
@@ -76,6 +112,28 @@ fmt.Printf("%s (%s) at %s:%d\n", short, full, file, line)
 ```go
 name, ok := runtimex.CallerFunc(0)
 fmt.Println(name) // e.g. "main"
+```
+
+### CallFrame
+
+```go
+f := runtimex.CallFrame(0)
+fmt.Println(f.Name())  // e.g. "main.main"
+fmt.Println(f.Short()) // e.g. "main"
+```
+
+### Memo
+
+```go
+// spans caches a span name derived once per call site.
+var spans runtimex.Memo[string]
+
+func handle() {
+	name := spans.Get(0, func(f runtimex.Frame) string {
+		return f.Short() // computed once for this call site
+	})
+	_ = name
+}
 ```
 
 ### Recover

--- a/runtime/cache.go
+++ b/runtime/cache.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"maps"
+	"sync"
+	"sync/atomic"
+)
+
+// cache is a copy-on-write map keyed by program counter.
+//
+// sync.Map is the obvious choice here and the wrong one: its Load takes an
+// any, so every lookup boxes the uintptr key and allocates. Because the key
+// space is bounded by the number of call sites and saturates within the first
+// moments of a process, copy-on-write is a better fit — reads are a lock-free
+// pointer load and a map index, and the O(n) clone on insert happens at most
+// once per call site.
+type cache[T any] struct {
+	mu sync.Mutex // serialises writers only
+	m  atomic.Pointer[map[uintptr]T]
+}
+
+func (c *cache[T]) load(pc uintptr) (T, bool) {
+	if m := c.m.Load(); m != nil {
+		v, ok := (*m)[pc]
+		return v, ok
+	}
+
+	var zero T
+
+	return zero, false
+}
+
+// store inserts pc if absent. Concurrent first calls from the same site are
+// harmless: the second simply overwrites an equal value.
+func (c *cache[T]) store(pc uintptr, v T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	old := c.m.Load()
+
+	next := make(map[uintptr]T, mapLen(old)+1)
+	if old != nil {
+		maps.Copy(next, *old)
+	}
+
+	next[pc] = v
+	c.m.Store(&next)
+}
+
+func mapLen[T any](m *map[uintptr]T) int {
+	if m == nil {
+		return 0
+	}
+
+	return len(*m)
+}

--- a/runtime/caller.go
+++ b/runtime/caller.go
@@ -2,18 +2,18 @@ package runtime
 
 import (
 	"path"
-	"runtime"
+	stdruntime "runtime"
 	"strings"
 )
 
 // Caller returns caller information for the function skip frames up the call stack.
 func Caller(skip int) (shortName, fullName, file string, line int, ok bool) { //nolint:nonamedreturns
-	pc, file, line, ok := runtime.Caller(skip + 1)
+	pc, file, line, ok := stdruntime.Caller(skip + 1)
 	if !ok {
 		return "unknown", "Unknown", "unknown", 0, false
 	}
 
-	fullName = runtime.FuncForPC(pc).Name()
+	fullName = stdruntime.FuncForPC(pc).Name()
 
 	dirname, filename := path.Split(file)
 	file = path.Join(path.Base(dirname), filename)

--- a/runtime/caller.go
+++ b/runtime/caller.go
@@ -8,12 +8,17 @@ import (
 
 // Caller returns caller information for the function skip frames up the call stack.
 func Caller(skip int) (shortName, fullName, file string, line int, ok bool) { //nolint:nonamedreturns
-	pc, file, line, ok := stdruntime.Caller(skip + 1)
-	if !ok {
+	var pcs [1]uintptr
+	if stdruntime.Callers(skip+2, pcs[:]) == 0 {
 		return "unknown", "Unknown", "unknown", 0, false
 	}
 
-	fullName = stdruntime.FuncForPC(pc).Name()
+	fr, _ := stdruntime.CallersFrames(pcs[:]).Next()
+	if fr.Function == "" {
+		return "unknown", "Unknown", "unknown", 0, false
+	}
+
+	fullName, file, line = fr.Function, fr.File, fr.Line
 
 	dirname, filename := path.Split(file)
 	file = path.Join(path.Base(dirname), filename)

--- a/runtime/caller_test.go
+++ b/runtime/caller_test.go
@@ -49,3 +49,17 @@ func TestCaller(t *testing.T) {
 	assert.Equal(t, "runtime/caller_test.go", file)
 	assert.Equal(t, 14, line)
 }
+
+// inlinedCaller is a leaf small enough for the compiler to inline into its
+// caller. With FuncForPC the reported name would be the inliner; via
+// CallersFrames it is correctly attributed to inlinedCaller.
+func inlinedCaller() string {
+	_, fullName, _, _, _ := runtime.Caller(0) //nolint:dogsled
+	return fullName
+}
+
+func TestCallerInlined(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "github.com/foomo/go/runtime_test.inlinedCaller", inlinedCaller())
+}

--- a/runtime/callframe.go
+++ b/runtime/callframe.go
@@ -1,0 +1,186 @@
+package runtime
+
+import (
+	stdruntime "runtime"
+	"strings"
+)
+
+// frames memoises symbolisation itself. Program counters are stable for the
+// lifetime of the process, so this map is bounded by the number of distinct
+// call sites that reach this package.
+var frames cache[Frame]
+
+// CallFrame returns the call site skip levels above its own caller: skip=0 is the
+// function that called Caller, skip=1 that function's caller, and so on.
+//
+// Symbolisation is memoised per program counter, so the steady-state cost is
+// one runtime.Callers into a stack array plus a map load, with no allocation.
+func CallFrame(skip int) Frame {
+	_, f := at(skip + 1)
+	return f
+}
+
+// at resolves the call site skip levels above at's caller (skip=0 being at's
+// immediate caller) and returns its program counter alongside the frame. The
+// pc doubles as the cache key for Memo.
+func at(skip int) (uintptr, Frame) {
+	var pcs [1]uintptr
+	// +2 accounts for stdruntime.Callers itself and for at, so that skip=0
+	// resolves to at's caller. Inlined frames are counted logically, so this
+	// arithmetic holds regardless of inlining decisions.
+	if stdruntime.Callers(skip+2, pcs[:]) == 0 {
+		return 0, Frame{}
+	}
+
+	pc := pcs[0]
+	if f, ok := frames.load(pc); ok {
+		return pc, f
+	}
+
+	return pc, resolve(pc)
+}
+
+// resolve symbolises pc and caches the result. It is deliberately a separate,
+// non-inlined function: stdruntime.CallersFrames retains the slice it is given,
+// so calling it in at would make at's pc buffer escape to the heap on every
+// call — escape analysis is not path-sensitive and cannot see that this branch
+// is taken at most once per call site.
+//
+//go:noinline
+func resolve(pc uintptr) Frame {
+	// CallersFrames expands inlined frames and adjusts return PCs to call PCs.
+	// stdruntime.FuncForPC on the same pc would report the inlining parent,
+	// silently attributing the call site to whatever function absorbed it.
+	fr, _ := stdruntime.CallersFrames([]uintptr{pc}).Next()
+	f := Frame{File: fr.File, Line: fr.Line}
+	f.Pkg, f.Inst, f.Func = parseName(fr.Function)
+	frames.store(pc, f)
+
+	return f
+}
+
+// parseName decomposes a qualified function name as reported by the runtime.
+// The shapes it handles:
+//
+//	pkg/path.Func
+//	pkg/path.Recv.Func                  value receiver
+//	pkg/path.(*Recv).Func               pointer receiver
+//	pkg/path.(Recv[go.shape.int]).Func  generic receiver
+//	pkg/path.Func.func1                 closure
+//	pkg/path.(*Recv).Func-fm            method value
+//	pkg/path.glob..func1                package-level var initializer
+//
+// One ambiguity is not resolvable from the string alone: a package path whose
+// final element contains a dot, such as gopkg.in/yaml.v3, is split at that dot
+// and its version element is mistaken for a receiver. The Go runtime has the
+// same limitation. Module paths using the standard /v2 suffix are unaffected.
+func parseName(fq string) (pkg, inst, fn string) { //nolint:nonamedreturns
+	if fq == "" {
+		return "", "", ""
+	}
+	// The package path ends at the first separator dot after the final slash.
+	start := strings.LastIndexByte(fq, '/') + 1
+
+	d := indexSep(fq[start:])
+	if d < 0 {
+		return fq, "", ""
+	}
+
+	pkg, rest := fq[:start+d], fq[start+d+1:]
+	if rest == "" {
+		return pkg, "", ""
+	}
+
+	// Parenthesised receiver. Parentheses do not nest in these names, so the
+	// first ')' followed by '.' closes the receiver.
+	if rest[0] == '(' {
+		if end := strings.IndexByte(rest, ')'); end > 1 && end+1 < len(rest) && rest[end+1] == '.' {
+			return pkg, strings.TrimPrefix(rest[1:end], "*"), rest[end+2:]
+		}
+	}
+
+	// Bare receiver. "Recv.Func" and "Func.func1" are indistinguishable by
+	// shape, so the second segment decides: a compiler-generated segment means
+	// the first one was the function, not a receiver type.
+	if segs := splitSep(rest); len(segs) >= 2 && !isGenerated(segs[1]) {
+		return pkg, segs[0], strings.Join(segs[1:], ".")
+	}
+
+	return pkg, "", rest
+}
+
+// indexSep returns the index of the first separator dot in s, ignoring dots
+// nested inside generic instantiation brackets such as [go.shape.int].
+func indexSep(s string) int {
+	depth := 0
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case '.':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+
+	return -1
+}
+
+// splitSep splits s on separator dots, ignoring those inside brackets.
+func splitSep(s string) []string {
+	var (
+		segs  []string
+		depth int
+		prev  int
+	)
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case '.':
+			if depth == 0 {
+				segs = append(segs, s[prev:i])
+				prev = i + 1
+			}
+		}
+	}
+
+	return append(segs, s[prev:])
+}
+
+// isGenerated reports whether seg is a compiler-generated name segment rather
+// than something written by a human: closure and wrapper markers, ordinal
+// suffixes, and the empty segment produced by "glob..func1".
+func isGenerated(seg string) bool {
+	switch seg {
+	case "", "glob", "stub":
+		return true
+	}
+
+	for _, prefix := range [...]string{"func", "deferwrap", "gowrap"} {
+		if suffix, ok := strings.CutPrefix(seg, prefix); ok && allDigits(suffix) {
+			return true
+		}
+	}
+
+	return allDigits(seg)
+}
+
+// allDigits reports whether s consists solely of ASCII digits. The empty
+// string counts, which is what lets "func" match alongside "func1".
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/runtime/callframe_test.go
+++ b/runtime/callframe_test.go
@@ -1,0 +1,80 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/foomo/go/runtime"
+)
+
+func TestParseName(t *testing.T) {
+	cases := []struct{ in, pkg, inst, fn string }{
+		{"main.main", "main", "", "main"},
+		{"github.com/b/billing/payment.Process", "github.com/b/billing/payment", "", "Process"},
+		{"github.com/b/billing/payment.(*Payment).Process", "github.com/b/billing/payment", "Payment", "Process"},
+		{"github.com/b/billing/payment.Payment.Process", "github.com/b/billing/payment", "Payment", "Process"},
+		{"github.com/b/billing/payment.(*Payment).Process.func1", "github.com/b/billing/payment", "Payment", "Process.func1"},
+		{"github.com/b/billing/payment.Process.func1", "github.com/b/billing/payment", "", "Process.func1"},
+		{"github.com/b/billing/payment.Process.func1.2", "github.com/b/billing/payment", "", "Process.func1.2"},
+		{"github.com/b/billing/payment.Map[go.shape.int]", "github.com/b/billing/payment", "", "Map[go.shape.int]"},
+		{"github.com/b/billing/payment.(*Cache[go.shape.string]).Get", "github.com/b/billing/payment", "Cache[go.shape.string]", "Get"},
+		{"github.com/b/billing/payment.(*Payment).Process-fm", "github.com/b/billing/payment", "Payment", "Process-fm"},
+		{"github.com/b/billing/payment.glob..func1", "github.com/b/billing/payment", "", "glob..func1"},
+		{"github.com/b/billing/payment.init.0", "github.com/b/billing/payment", "", "init.0"},
+		{"github.com/b/svc/v2.Run", "github.com/b/svc/v2", "", "Run"},
+		{"", "", "", ""},
+	}
+	for _, c := range cases {
+		pkg, inst, fn := runtime.ParseName(c.in)
+		if pkg != c.pkg || inst != c.inst || fn != c.fn {
+			t.Errorf("parseName(%q)\n got  pkg=%q inst=%q fn=%q\n want pkg=%q inst=%q fn=%q",
+				c.in, pkg, inst, fn, c.pkg, c.inst, c.fn)
+		}
+	}
+}
+
+//nolint:recvcheck // intentionally
+type widget struct{}
+
+func (w *widget) ptrMethod() runtime.Frame { return runtime.CallFrame(0) }
+func (w widget) valMethod() runtime.Frame  { return runtime.CallFrame(0) }
+func pkgFunc() runtime.Frame               { return runtime.CallFrame(0) }
+func nested() runtime.Frame                { return func() runtime.Frame { return runtime.CallFrame(0) }() }
+func indirect() runtime.Frame              { return level2() }
+func level2() runtime.Frame                { return runtime.CallFrame(1) }
+func generic[T any](v T) runtime.Frame     { return runtime.CallFrame(0) }
+
+func TestCallFrame(t *testing.T) {
+	cases := []struct {
+		got      runtime.Frame
+		inst, fn string
+	}{
+		{(&widget{}).ptrMethod(), "widget", "ptrMethod"},
+		{widget{}.valMethod(), "widget", "valMethod"},
+		{pkgFunc(), "", "pkgFunc"},
+		{nested(), "", "nested.func1"},
+		{indirect(), "", "indirect"},
+		{generic(42), "", "generic[...]"},
+	}
+	for _, c := range cases {
+		if c.got.Inst != c.inst || c.got.Func != c.fn {
+			t.Errorf("got inst=%q fn=%q, want inst=%q fn=%q (name=%q)",
+				c.got.Inst, c.got.Func, c.inst, c.fn, c.got.Name())
+		}
+
+		if c.got.Line == 0 || c.got.File == "" {
+			t.Errorf("%s: missing file/line", c.got.Name())
+		}
+
+		if c.got.Pkg != "github.com/foomo/go/runtime_test" {
+			t.Errorf("%s: unexpected pkg %q", c.got.Name(), c.got.Pkg)
+		}
+	}
+}
+
+func BenchmarkCallFrame(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = runtime.CallFrame(0)
+	}
+}

--- a/runtime/export_test.go
+++ b/runtime/export_test.go
@@ -1,0 +1,3 @@
+package runtime
+
+var ParseName = parseName

--- a/runtime/frame.go
+++ b/runtime/frame.go
@@ -1,0 +1,42 @@
+package runtime
+
+// Frame identifies a single call site.
+//
+// Pkg is the full import path, Inst the receiver type name for methods (empty
+// for package-level functions), and Func the function or method name including
+// any compiler-generated suffix such as ".func1" or "-fm".
+type Frame struct {
+	Pkg  string // "github.com/foomo/go/runtime"
+	Inst string // "Memo"; empty for package-level functions
+	Func string // "Get", "Meemo.func1", "Map[go.shape.int]"
+	File string // absolute path as recorded at build time
+	Line int
+}
+
+// Name reassembles the qualified name, suitable for the code.function.name
+// attribute. The receiver's pointer marker is not preserved: a method on
+// *Payment and one on Payment both render as "pkg.Payment.Method".
+func (f Frame) Name() string {
+	switch {
+	case f.Pkg == "":
+		return f.Func
+	case f.Inst == "":
+		return f.Pkg + "." + f.Func
+	default:
+		return f.Pkg + "." + f.Inst + "." + f.Func
+	}
+}
+
+// Short renders the receiver-qualified name without the package path, e.g.
+// "Payment.Process" or "Process" for a package-level function.
+func (f Frame) Short() string {
+	if f.Inst == "" {
+		return f.Func
+	}
+
+	return f.Inst + "." + f.Func
+}
+
+// Zero reports whether the frame could not be resolved. A zero Frame is
+// returned rather than a panic when the stack is unavailable.
+func (f Frame) Zero() bool { return f.Func == "" && f.Pkg == "" }

--- a/runtime/memo.go
+++ b/runtime/memo.go
@@ -1,0 +1,34 @@
+package runtime
+
+// Memo caches a value of type T per call site.
+//
+// It exists so that per-site derived data — a span name, a preformatted
+// attribute slice, a logger — is computed once for the life of the process
+// rather than on every call. Each Memo is its own namespace, so several may
+// derive different values from the same call site. The zero value is ready to
+// use and a Memo must not be copied after first use.
+type Memo[T any] struct {
+	c cache[T]
+}
+
+// Get returns the memoised value for the call site skip levels above Get's
+// caller: skip=0 is the function that called Get.
+//
+// derive is invoked at most once per call site under normal conditions, but
+// concurrent first calls from the same site may each run it and race to store;
+// derive must therefore be pure and its result safe to share. Values handed
+// out by Get are shared across all calls from that site and must be treated as
+// read-only.
+func (mo *Memo[T]) Get(skip int, derive func(Frame) T) T {
+	pc, f := at(skip + 1)
+	if v, ok := mo.c.load(pc); ok {
+		return v
+	}
+
+	v := derive(f)
+	if pc != 0 { // unresolvable stack: derive, but never poison the cache
+		mo.c.store(pc, v)
+	}
+
+	return v
+}

--- a/runtime/memo_test.go
+++ b/runtime/memo_test.go
@@ -1,0 +1,63 @@
+package runtime_test
+
+import (
+	"sync"
+	"testing"
+
+	goruntime "github.com/foomo/go/runtime"
+)
+
+func TestMemoPerCallSite(t *testing.T) {
+	var (
+		m     goruntime.Memo[string]
+		calls int
+	)
+
+	derive := func(f goruntime.Frame) string { calls++; return f.Short() }
+
+	// Same call site (the loop body), repeated: derive must run once.
+	for range 3 {
+		if v := m.Get(0, derive); v != "TestMemoPerCallSite" {
+			t.Fatalf("got %q", v)
+		}
+	}
+
+	if calls != 1 {
+		t.Fatalf("derive ran %d times, want 1", calls)
+	}
+
+	// A second, textually distinct call site in the same function is a
+	// distinct program counter and therefore a distinct entry.
+	if v := m.Get(0, derive); v != "TestMemoPerCallSite" || calls != 2 {
+		t.Fatalf("got %q after %d derives", v, calls)
+	}
+}
+
+func TestMemoConcurrent(t *testing.T) {
+	var (
+		m  goruntime.Memo[int]
+		wg sync.WaitGroup
+	)
+	for range 64 {
+		wg.Go(func() {
+			if v := m.Get(0, func(goruntime.Frame) int { return 7 }); v != 7 {
+				t.Errorf("got %d", v)
+			}
+		})
+	}
+
+	wg.Wait()
+}
+
+func BenchmarkMemoGet(b *testing.B) {
+	var m goruntime.Memo[string]
+
+	derive := func(f goruntime.Frame) string { return f.Short() }
+	m.Get(0, derive)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = m.Get(0, derive)
+	}
+}


### PR DESCRIPTION
### Description

Add `runtime.CallFrame` for allocation-free, inlining-aware call-site resolution.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests

### Changes

- Add `CallFrame(skip)` returning structured `Frame` (pkg, inst, func, file, line); `parseName` decomposes qualified runtime names (value/pointer/generic receivers, closures, method values, initializers).
- Add copy-on-write per-PC `cache` — lock-free reads, no per-lookup alloc vs `sync.Map`; `resolve` kept `//go:noinline` so PC buffer stays off heap.
- Switch `Caller` to `runtime.Callers` + `CallersFrames` — inlined frames resolve to real call site, not inlining parent.
- Add `docs/runtime.md` + README pointer.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.