### PR TITLE
feat: add controlable time

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Go standard library extension, adding the missing parts used in the foomo ecosys
 - **slog** — Test-friendly `slog.Handler` that writes to `testing.TB` output
 - **strings** — Case conversions, padding, validation, prefix/suffix matching, and composition
 - **testing** — Tag-based test filtering via `GO_TEST_TAGS`, crypto key helpers, `ExampleTB`
-- **time** — Context-aware `Sleep` and polling `WaitFor`; `ParseDuration` (adds `d`/`w` units)
+- **time** — Context-aware `Sleep` and polling `WaitFor`; `ParseDuration` (adds `d`/`w` units); swappable `Now` clock for deterministic and time-travel tests (`Static`, `Incremental`)
 - **types** — Common interface contracts (`Closer`, `Starter`, `Stopper`, …) with function adapters and `As<X>` helpers
 
 ## How to Contribute

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,11 +1,85 @@
 # time
 
-Context-aware time utilities and duration parsing.
+Context-aware time utilities, duration parsing, and a controllable clock.
 
 ## Import
 
 ```go
 import timex "github.com/foomo/go/time"
+```
+
+## Time control
+
+`Now` is a package-level variable (defaulting to `time.Now`) that acts as the application's
+clock. Call `timex.Now()` instead of the standard library `time.Now()` throughout your code,
+then swap the provider to control time — for time travel or deterministic unit test outputs.
+
+### Now
+
+```go
+var Now = time.Now
+```
+
+The current-time provider. Invoke `timex.Now()` wherever you would call `time.Now()`.
+Reassign it (directly, or via `Static`/`Incremental`) to take control of the clock.
+
+### Static
+
+```go
+func Static()
+```
+
+Points `Now` at a static provider: every call returns the same instant,
+`time.Unix(0, NowStaticNSec)` (default `2021-01-01 12:00:00`). Ideal for fixed, reproducible
+timestamps in tests and golden files.
+
+### Incremental
+
+```go
+func Incremental()
+```
+
+Points `Now` at an incremental provider: each call returns a strictly increasing instant,
+starting at `time.Unix(0, NowIncrementalNSec)` and advancing one nanosecond per call. Useful
+when you need distinct but deterministic timestamps (e.g. stable ordering).
+
+### ResetIncremental
+
+```go
+func ResetIncremental()
+```
+
+Rewinds the incremental provider's cursor (`NowIncrementalNSec`) back to `NowStaticNSec`.
+
+### Tunables
+
+```go
+var NowStaticNSec      = int64(1609498800e9) // 2021-01-01 12:00:00 (11:00:00 UTC), in Unix nanoseconds
+var NowIncrementalNSec = NowStaticNSec       // current incremental cursor
+```
+
+Adjust `NowStaticNSec` to change the fixed instant used by `Static` (it also seeds the
+incremental cursor). `NowIncrementalNSec` holds the incremental provider's current position.
+
+## Example
+
+```go
+// In production code, always read the clock through timex.Now.
+func stamp() time.Time { return timex.Now() }
+
+// In a test, freeze time for deterministic output.
+timex.Static()
+fmt.Println(stamp().UTC().Format(time.RFC3339)) // 2021-01-01T11:00:00Z
+fmt.Println(stamp().UTC().Format(time.RFC3339)) // 2021-01-01T11:00:00Z (unchanged)
+
+// Or advance deterministically, one nanosecond per call.
+timex.Incremental()
+a := stamp()
+b := stamp()
+fmt.Println(b.After(a)) // true
+
+// Restore the default clock when done.
+timex.Now = time.Now
 ```
 
 ## API

--- a/time/time.go
+++ b/time/time.go
@@ -1,0 +1,55 @@
+package time
+
+import (
+	"time"
+)
+
+var (
+	// Now returns the current time. It is a package-level variable so it can be
+	// swapped out to control time, e.g., for time travel or deterministic unit
+	// test outputs. Call timex.Now() instead of the standard library time.Now(),
+	// then use Static or Incremental to take control of the clock.
+	//
+	// It defaults to the standard library time.Now.
+	Now = time.Now
+
+	// NowStaticNSec is the fixed instant, in Unix nanoseconds, returned by the
+	// static provider installed via Static. It also seeds NowIncrementalNSec.
+	// Defaults to 2021-01-01 12:00:00 (11:00:00 UTC).
+	NowStaticNSec = int64(1609498800e9) // 2021-01-01 12:00:00
+
+	// NowIncrementalNSec is the current cursor, in Unix nanoseconds, used by the
+	// incremental provider installed via Incremental. It advances by one
+	// nanosecond on every call to Now and can be rewound with ResetIncremental.
+	NowIncrementalNSec = NowStaticNSec
+)
+
+// Static points Now at a static time provider: every call to Now returns the
+// same instant, time.Unix(0, NowStaticNSec).
+func Static() {
+	Now = static
+}
+
+// Incremental points Now at an incremental time provider: each call to Now
+// returns a strictly increasing instant, starting at time.Unix(0,
+// NowIncrementalNSec) and advancing by one nanosecond per call.
+func Incremental() {
+	Now = incremental
+}
+
+func static() time.Time {
+	return time.Unix(0, NowStaticNSec)
+}
+
+func incremental() time.Time {
+	t := time.Unix(0, NowIncrementalNSec)
+	NowIncrementalNSec++
+
+	return t
+}
+
+// ResetIncremental rewinds the incremental provider's cursor back to the static
+// default (NowStaticNSec).
+func ResetIncremental() {
+	NowIncrementalNSec = NowStaticNSec
+}

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,0 +1,90 @@
+package time_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	timex "github.com/foomo/go/time"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Restore captures the mutable package globals and reinstates them on cleanup so
+// that controlling the clock in one test does not leak into sibling tests. The
+// globals are shared state, so these tests must not run in parallel.
+func restore(t *testing.T) {
+	t.Helper()
+
+	now := timex.Now
+	static := timex.NowStaticNSec
+	incremental := timex.NowIncrementalNSec
+
+	t.Cleanup(func() {
+		timex.Now = now
+		timex.NowStaticNSec = static
+		timex.NowIncrementalNSec = incremental
+	})
+}
+
+func TestStatic(t *testing.T) {
+	restore(t)
+
+	timex.Static()
+
+	want := time.Unix(0, timex.NowStaticNSec)
+
+	first := timex.Now()
+	second := timex.Now()
+
+	assert.Equal(t, want, first)
+	// Every call returns the very same instant.
+	assert.Equal(t, first, second)
+}
+
+func TestIncremental(t *testing.T) {
+	restore(t)
+
+	timex.Incremental()
+
+	first := timex.Now()
+	require.Equal(t, time.Unix(0, timex.NowStaticNSec), first)
+
+	second := timex.Now()
+	// Strictly increasing by one nanosecond per call.
+	assert.Equal(t, first.Add(time.Nanosecond), second)
+	assert.True(t, second.After(first))
+}
+
+func TestResetIncremental(t *testing.T) {
+	restore(t)
+
+	timex.Incremental()
+	timex.Now()
+	timex.Now()
+	require.Greater(t, timex.NowIncrementalNSec, timex.NowStaticNSec)
+
+	timex.ResetIncremental()
+	assert.Equal(t, timex.NowStaticNSec, timex.NowIncrementalNSec)
+}
+
+func TestNowDefault(t *testing.T) {
+	restore(t)
+
+	// The default provider is a live clock.
+	assert.WithinDuration(t, time.Now(), timex.Now(), time.Minute)
+}
+
+func ExampleStatic() {
+	// Save and restore the default clock so the example is self-contained.
+	defer func() { timex.Now = time.Now }()
+
+	timex.Static()
+
+	fmt.Println(timex.Now().UTC().Format(time.RFC3339))
+	fmt.Println(timex.Now().UTC().Format(time.RFC3339))
+
+	// Output:
+	// 2021-01-01T11:00:00Z
+	// 2021-01-01T11:00:00Z
+}


### PR DESCRIPTION
### Description

Document, test, and expose the `time` package's controllable clock (`Now`) for time-travel and deterministic test output.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- Add godoc to the swappable clock in `time/time.go` — `Now`, `Static`, `Incremental`, `ResetIncremental`, and the `NowStaticNSec`/`NowIncrementalNSec` tunables — explaining use for time travel and deterministic unit-test output. No behaviour or signature changes.
- Add `time/time_test.go` (black-box `time_test`): `TestStatic`, `TestIncremental`, `TestResetIncremental`, `TestNowDefault`, and `ExampleStatic`, with a `restore` cleanup helper that reinstates the mutable package globals so clock control does not leak into sibling tests (hence no `t.Parallel()`).
- Add a "Time control" section to `docs/time.md` documenting the clock API with a usage example.
- Extend the `time` bullet in `README.md` to mention the swappable `Now` clock.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
