### PR TITLE
style: use "go" as prefix for package alias

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -55,6 +55,11 @@ linters:
 
   # https://golangci-lint.run/docs/linters/
   settings:
+    # https://golangci-lint.run/docs/linters/configuration/#importas
+    importas:
+      alias:
+        - pkg: github.com/foomo/go/([\w\d]+)
+          alias: go$1
     # https://golangci-lint.run/docs/linters/configuration/#goconst
     goconst:
       min-occurrences: 5

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -5,7 +5,7 @@ Helpers extending the standard `errors` package.
 ## Import
 
 ```go
-import errorsx "github.com/foomo/go/errors"
+import goerrors "github.com/foomo/go/errors"
 ```
 
 ## API
@@ -37,7 +37,7 @@ var (
 )
 
 _, err := os.Open("/nonexistent/path")
-if errorsx.AsAny(err, &numErr, &pathErr) {
+if goerrors.AsAny(err, &numErr, &pathErr) {
 	// err unwrapped into one of the targets
 }
 ```
@@ -46,7 +46,7 @@ if errorsx.AsAny(err, &numErr, &pathErr) {
 
 ```go
 err := fmt.Errorf("wrapped: %w", io.EOF)
-if errorsx.IsAny(err, context.Canceled, io.EOF) {
+if goerrors.IsAny(err, context.Canceled, io.EOF) {
 	// err matches one of the sentinels
 }
 ```

--- a/docs/fmt.md
+++ b/docs/fmt.md
@@ -5,7 +5,7 @@ Template string formatting utility.
 ## Import
 
 ```go
-import fmtx "github.com/foomo/go/fmt"
+import gofmt "github.com/foomo/go/fmt"
 ```
 
 ## API
@@ -26,11 +26,11 @@ package main
 import (
 	"fmt"
 
-	fmtx "github.com/foomo/go/fmt"
+	gofmt "github.com/foomo/go/fmt"
 )
 
 func main() {
-	result := fmtx.Tprintf("%{.name} is %{.age} years old", "name", "John", "age", "30")
+	result := gofmt.Tprintf("%{.name} is %{.age} years old", "name", "John", "age", "30")
 	fmt.Println(result)
 	// Output: John is 30 years old
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hero:
 
 features:
   - title: Stdlib Mirror Naming
-    details: Packages mirror Go standard library naming with an x suffix alias convention — netx, osx, fmtx — so imports stay intuitive.
+    details: Packages mirror Go standard library naming with a go prefix alias convention — gonet, goos, gofmt — so imports stay intuitive.
   - title: Generic Utilities
     details: Type-safe generic functions for slices (Filter, Map, GroupBy) and the functional options pattern (Option, OptionE).
   - title: Testing Helpers

--- a/docs/net.md
+++ b/docs/net.md
@@ -5,7 +5,7 @@ Network utilities — free port allocation and TCP connection wait helpers.
 ## Import
 
 ```go
-import netx "github.com/foomo/go/net"
+import gonet "github.com/foomo/go/net"
 ```
 
 ## API
@@ -61,20 +61,20 @@ import (
 	"log"
 	"time"
 
-	netx "github.com/foomo/go/net"
+	gonet "github.com/foomo/go/net"
 )
 
 func main() {
 	ctx := context.Background()
 
-	port, err := netx.FreePort(ctx)
+	port, err := gonet.FreePort(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println(port) // e.g. 54321
 
 	// Wait for a service to come up on the port (max 5s).
-	if err := netx.WaitForFreePort(ctx, port, 5*time.Second); err != nil {
+	if err := gonet.WaitForFreePort(ctx, port, 5*time.Second); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/docs/os.md
+++ b/docs/os.md
@@ -5,7 +5,7 @@ Typed environment variable parsing with defaults, plus path expansion helpers.
 ## Import
 
 ```go
-import osx "github.com/foomo/go/os"
+import goos "github.com/foomo/go/os"
 ```
 
 ## Package Variables
@@ -130,7 +130,7 @@ func Expand(s string) (string, error)
 Expands a leading `~/` to the user's home directory and resolves environment variable references via `os.ExpandEnv`. Returns an error if the home directory cannot be determined.
 
 ```go
-path, err := osx.Expand("~/.config/$APP_NAME/config.yaml")
+path, err := goos.Expand("~/.config/$APP_NAME/config.yaml")
 if err != nil {
 	log.Fatal(err)
 }
@@ -148,31 +148,31 @@ import (
 	"fmt"
 	"os"
 
-	osx "github.com/foomo/go/os"
+	goos "github.com/foomo/go/os"
 )
 
 func main() {
 	// String with default
-	host := osx.Getenv("APP_HOST", "localhost")
+	host := goos.Getenv("APP_HOST", "localhost")
 	fmt.Println(host)
 
 	// Check existence
-	if osx.HasEnv("DATABASE_URL") {
+	if goos.HasEnv("DATABASE_URL") {
 		fmt.Println("database configured")
 	}
 
 	// Typed parsing
 	os.Setenv("DEBUG", "true")
-	debug, _ := osx.GetenvBool("DEBUG", false)
+	debug, _ := goos.GetenvBool("DEBUG", false)
 	fmt.Println(debug) // true
 
 	os.Setenv("PORT", "8080")
-	port, _ := osx.GetenvInt32("PORT", 3000)
+	port, _ := goos.GetenvInt32("PORT", 3000)
 	fmt.Println(port) // 8080
 
 	// Duration
 	os.Setenv("TIMEOUT", "30s")
-	timeout, _ := osx.GetenvDuration("TIMEOUT", 10*time.Second)
+	timeout, _ := goos.GetenvDuration("TIMEOUT", 10*time.Second)
 	fmt.Println(timeout) // 30s
 }
 ```
@@ -181,28 +181,28 @@ func main() {
 
 ```go
 // Panics if DATABASE_URL is not set
-dsn := osx.MustGetenv("DATABASE_URL")
+dsn := goos.MustGetenv("DATABASE_URL")
 
 // Panics if PORT is not set or not a valid int
-port := osx.MustGetenvInt("PORT")
+port := goos.MustGetenvInt("PORT")
 ```
 
 ### Slices and maps
 
 ```go
 os.Setenv("ALLOWED_ORIGINS", "foo.com, bar.com, baz.com")
-origins := osx.GetenvStringSlice("ALLOWED_ORIGINS", nil)
+origins := goos.GetenvStringSlice("ALLOWED_ORIGINS", nil)
 // origins = ["foo.com", "bar.com", "baz.com"]
 
 os.Setenv("PORTS", "8080,8081,8082")
-ports, _ := osx.GetenvIntSlice("PORTS", nil)
+ports, _ := goos.GetenvIntSlice("PORTS", nil)
 // ports = [8080, 8081, 8082]
 
 os.Setenv("LABELS", "env:prod, region:eu")
-labels, _ := osx.GetenvStringMap("LABELS", nil)
+labels, _ := goos.GetenvStringMap("LABELS", nil)
 // labels = map["env":"prod", "region":"eu"]
 
 os.Setenv("TIMEOUTS", "read:5s,write:10s")
-timeouts, _ := osx.GetenvDurationMap("TIMEOUTS", nil)
+timeouts, _ := goos.GetenvDurationMap("TIMEOUTS", nil)
 // timeouts = map["read":5s, "write":10s]
 ```

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -5,7 +5,7 @@ Runtime introspection utilities.
 ## Import
 
 ```go
-import runtimex "github.com/foomo/go/runtime"
+import goruntime "github.com/foomo/go/runtime"
 ```
 
 ## API
@@ -102,7 +102,7 @@ Represents a recovered panic with captured runtime context. `Unwrap` returns the
 ### Caller
 
 ```go
-short, full, file, line, ok := runtimex.Caller(0)
+short, full, file, line, ok := goruntime.Caller(0)
 fmt.Printf("%s (%s) at %s:%d\n", short, full, file, line)
 // e.g. main.main (main.main) at main/main.go:12
 ```
@@ -110,14 +110,14 @@ fmt.Printf("%s (%s) at %s:%d\n", short, full, file, line)
 ### CallerFunc
 
 ```go
-name, ok := runtimex.CallerFunc(0)
+name, ok := goruntime.CallerFunc(0)
 fmt.Println(name) // e.g. "main"
 ```
 
 ### CallFrame
 
 ```go
-f := runtimex.CallFrame(0)
+f := goruntime.CallFrame(0)
 fmt.Println(f.Name())  // e.g. "main.main"
 fmt.Println(f.Short()) // e.g. "main"
 ```
@@ -126,10 +126,10 @@ fmt.Println(f.Short()) // e.g. "main"
 
 ```go
 // spans caches a span name derived once per call site.
-var spans runtimex.Memo[string]
+var spans goruntime.Memo[string]
 
 func handle() {
-	name := spans.Get(0, func(f runtimex.Frame) string {
+	name := spans.Get(0, func(f goruntime.Frame) string {
 		return f.Short() // computed once for this call site
 	})
 	_ = name
@@ -139,11 +139,11 @@ func handle() {
 ### Recover
 
 ```go
-err := runtimex.Recover(func() {
+err := goruntime.Recover(func() {
 	panic("something went wrong")
 })
 
-var pe *runtimex.PanicError
+var pe *goruntime.PanicError
 if errors.As(err, &pe) {
 	fmt.Println(pe.Value) // "something went wrong"
 	fmt.Println(pe.Stack) // full stack trace
@@ -153,7 +153,7 @@ if errors.As(err, &pe) {
 ### StackTrace
 
 ```go
-trace := runtimex.StackTrace(5, 0)
+trace := goruntime.StackTrace(5, 0)
 fmt.Println(trace)
 // main.handler
 //   server/handler.go:28

--- a/docs/sec.md
+++ b/docs/sec.md
@@ -5,7 +5,7 @@ Security utilities.
 ## Import
 
 ```go
-import secx "github.com/foomo/go/sec"
+import gosec "github.com/foomo/go/sec"
 ```
 
 ## API
@@ -24,14 +24,14 @@ This is the recommended way to construct file paths from user-supplied input, ad
 
 ```go
 // Safe path — stays within root
-path, err := secx.Filename("/srv/data", "users", "profile.json")
+path, err := gosec.Filename("/srv/data", "users", "profile.json")
 // path = "/srv/data/users/profile.json", err = nil
 
 // Traversal attempt — blocked
-path, err = secx.Filename("/srv/data", "../etc/passwd")
+path, err = gosec.Filename("/srv/data", "../etc/passwd")
 // path = "", err = "path traversal attempt"
 
 // Empty root — rejected
-path, err = secx.Filename("", "file.txt")
+path, err = gosec.Filename("", "file.txt")
 // path = "", err = "root required"
 ```

--- a/docs/slog.md
+++ b/docs/slog.md
@@ -5,7 +5,7 @@ Test-friendly `slog.Handler` that writes log output through `testing.TB`.
 ## Import
 
 ```go
-import slogx "github.com/foomo/go/slog"
+import goslog "github.com/foomo/go/slog"
 ```
 
 ## API
@@ -36,7 +36,7 @@ Sets the minimum log level for the test handler.
 
 ```go
 func TestService(t *testing.T) {
-	logger := slog.New(slogx.NewTestHandler(t))
+	logger := slog.New(goslog.NewTestHandler(t))
 	logger.Info("starting", "port", 8080)
 	// Output via t.Log: testfile_test.go:4: [INFO] starting port=8080
 }
@@ -46,7 +46,7 @@ func TestService(t *testing.T) {
 
 ```go
 func TestServiceWarn(t *testing.T) {
-	logger := slog.New(slogx.NewTestHandler(t, slogx.TestHandlerWithLevel(slog.LevelWarn)))
+	logger := slog.New(goslog.NewTestHandler(t, goslog.TestHandlerWithLevel(slog.LevelWarn)))
 	logger.Debug("ignored") // not printed
 	logger.Warn("something happened", "err", "timeout")
 }

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -5,7 +5,7 @@ String manipulation utilities including case conversions, padding, substring rem
 ## Import
 
 ```go
-import stringsx "github.com/foomo/go/strings"
+import gostrings "github.com/foomo/go/strings"
 ```
 
 ## API
@@ -118,44 +118,44 @@ Returns `true` if the string starts (or ends) with any of the provided values. R
 ### Case conversions
 
 ```go
-stringsx.ToCamel("hello_world")         // "HelloWorld"
-stringsx.ToSnake("HelloWorld")           // "hello_world"
-stringsx.ToKebab("HelloWorld")           // "hello-world"
-stringsx.ToScreamingSnake("HelloWorld")  // "HELLO_WORLD"
+gostrings.ToCamel("hello_world")         // "HelloWorld"
+gostrings.ToSnake("HelloWorld")           // "hello_world"
+gostrings.ToKebab("HelloWorld")           // "hello-world"
+gostrings.ToScreamingSnake("HelloWorld")  // "HELLO_WORLD"
 ```
 
 ### Padding
 
 ```go
-fmt.Printf("'%s'", stringsx.PadRight("hello", 10))
+fmt.Printf("'%s'", gostrings.PadRight("hello", 10))
 // Output: 'hello     '
 
-fmt.Printf("'%s'", stringsx.PadLeft("hello", 10))
+fmt.Printf("'%s'", gostrings.PadLeft("hello", 10))
 // Output: '     hello'
 ```
 
 ### RemoveAll
 
 ```go
-result := stringsx.RemoveAll("hello world", "o", "l")
+result := gostrings.RemoveAll("hello world", "o", "l")
 fmt.Println(result) // "he wrd"
 ```
 
 ### Validation
 
 ```go
-stringsx.IsEmpty("")           // true
-stringsx.IsBlank("  \t")      // true
-stringsx.IsAnyEmpty("a", "")  // true
-stringsx.IsAlpha("Hello")     // true
-stringsx.IsAlphanumeric("Go1") // true
-stringsx.IsNumeric("12345")   // true
-stringsx.IsNumerical("3.14")  // true
+gostrings.IsEmpty("")           // true
+gostrings.IsBlank("  \t")      // true
+gostrings.IsAnyEmpty("a", "")  // true
+gostrings.IsAlpha("Hello")     // true
+gostrings.IsAlphanumeric("Go1") // true
+gostrings.IsNumeric("12345")   // true
+gostrings.IsNumerical("3.14")  // true
 ```
 
 ### Prefix / Suffix
 
 ```go
-stringsx.HasAnyPrefix("/api/users", "/api", "/admin") // true
-stringsx.HasAnySuffix("image.png", ".jpg", ".png")    // true
+gostrings.HasAnyPrefix("/api/users", "/api", "/admin") // true
+gostrings.HasAnySuffix("image.png", ".jpg", ".png")    // true
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@ Testing utilities including tag-based test filtering, network helpers, and crypt
 ## Import
 
 ```go
-import testingx "github.com/foomo/go/testing"
+import gotesting "github.com/foomo/go/testing"
 import tagx "github.com/foomo/go/testing/tag"
 ```
 
@@ -96,12 +96,12 @@ const (
 
 ```go
 func TestDatabaseIntegration(t *testing.T) {
-	testingx.Tags(t, tagx.Integration)
+	gotesting.Tags(t, tagx.Integration)
 	// test body ...
 }
 
 func TestQuickCheck(t *testing.T) {
-	testingx.Tags(t, tagx.Short)
+	gotesting.Tags(t, tagx.Short)
 	// test body ...
 }
 ```
@@ -142,7 +142,7 @@ A wrapper type that implements the `M` interface. Useful for adapting `testing.M
 
 ```go
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(testingx.MFunc(func() int {
+	goleak.VerifyTestMain(gotesting.MFunc(func() int {
 		return m.Run()
 	}))
 }
@@ -160,7 +160,7 @@ Returns a free port on localhost. Calls `tb.Fatal` on error.
 
 ```go
 func TestServer(t *testing.T) {
-	port := testingx.FreePort(t)
+	port := gotesting.FreePort(t)
 	// port = 54321
 }
 ```
@@ -175,7 +175,7 @@ Returns `n` free ports on localhost. Calls `tb.Fatal` on error. All listeners ar
 
 ```go
 func TestCluster(t *testing.T) {
-	ports := testingx.FreePorts(t, 3)
+	ports := gotesting.FreePorts(t, 3)
 	// ports = [54321, 54322, 54323]
 }
 ```
@@ -190,9 +190,9 @@ Waits in parallel for TCP connections to succeed on each of the given localhost 
 
 ```go
 func TestServerStarts(t *testing.T) {
-	port := testingx.FreePort(t)
+	port := gotesting.FreePort(t)
 	go startServer(t, port)
-	testingx.WaitForFreePorts(t, port)
+	gotesting.WaitForFreePorts(t, port)
 	// server is now reachable
 }
 ```
@@ -226,10 +226,10 @@ func GenerateED25519PublicKey(tb testing.TB, privateKey ed25519.PrivateKey, file
 ```go
 func TestJWT(t *testing.T) {
 	// Generate RSA key pair (files cleaned up after test)
-	publicKeyPath, privateKeyPath := testingx.GenerateRSAKeyPair(t)
+	publicKeyPath, privateKeyPath := gotesting.GenerateRSAKeyPair(t)
 
 	// Or generate ED25519 keys
-	edPub, edPriv := testingx.GenerateED25519KeyPair(t)
+	edPub, edPriv := gotesting.GenerateED25519KeyPair(t)
 }
 ```
 
@@ -254,8 +254,8 @@ Implements: `Name`, `Helper`, `Cleanup`, `Fail`, `FailNow`, `Failed`, `Error`, `
 
 ```go
 func ExampleFreePort() {
-	tb := testingx.NewExampleTB()
-	addr := testingx.FreePort(tb)
+	tb := gotesting.NewExampleTB()
+	addr := gotesting.FreePort(tb)
 	fmt.Println(addr)
 }
 ```

--- a/docs/time.md
+++ b/docs/time.md
@@ -5,13 +5,13 @@ Context-aware time utilities, duration parsing, and a controllable clock.
 ## Import
 
 ```go
-import timex "github.com/foomo/go/time"
+import gotime "github.com/foomo/go/time"
 ```
 
 ## Time control
 
 `Now` is a package-level variable (defaulting to `time.Now`) that acts as the application's
-clock. Call `timex.Now()` instead of the standard library `time.Now()` throughout your code,
+clock. Call `gotime.Now()` instead of the standard library `time.Now()` throughout your code,
 then swap the provider to control time — for time travel or deterministic unit test outputs.
 
 ### Now
@@ -20,7 +20,7 @@ then swap the provider to control time — for time travel or deterministic unit
 var Now = time.Now
 ```
 
-The current-time provider. Invoke `timex.Now()` wherever you would call `time.Now()`.
+The current-time provider. Invoke `gotime.Now()` wherever you would call `time.Now()`.
 Reassign it (directly, or via `Static`/`Incremental`) to take control of the clock.
 
 ### Static
@@ -64,22 +64,22 @@ incremental cursor). `NowIncrementalNSec` holds the incremental provider's curre
 ## Example
 
 ```go
-// In production code, always read the clock through timex.Now.
-func stamp() time.Time { return timex.Now() }
+// In production code, always read the clock through gotime.Now.
+func stamp() time.Time { return gotime.Now() }
 
 // In a test, freeze time for deterministic output.
-timex.Static()
+gotime.Static()
 fmt.Println(stamp().UTC().Format(time.RFC3339)) // 2021-01-01T11:00:00Z
 fmt.Println(stamp().UTC().Format(time.RFC3339)) // 2021-01-01T11:00:00Z (unchanged)
 
 // Or advance deterministically, one nanosecond per call.
-timex.Incremental()
+gotime.Incremental()
 a := stamp()
 b := stamp()
 fmt.Println(b.After(a)) // true
 
 // Restore the default clock when done.
-timex.Now = time.Now
+gotime.Now = time.Now
 ```
 
 ## API
@@ -117,7 +117,7 @@ ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 defer cancel()
 
 // Wait for 1 second (completes successfully)
-err := timex.Sleep(ctx, 1*time.Second)
+err := gotime.Sleep(ctx, 1*time.Second)
 if err != nil {
 	fmt.Println("Sleep failed:", err)
 	return
@@ -129,7 +129,7 @@ fmt.Println("Sleep completed successfully")
 ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
 defer cancel2()
 
-err = timex.Sleep(ctx2, 3*time.Second)
+err = gotime.Sleep(ctx2, 3*time.Second)
 if err != nil {
 	fmt.Println("Sleep cancelled:", err)
 }
@@ -143,7 +143,7 @@ if err != nil {
 
 ```go
 // Poll a readiness check up to 10s, every 250ms.
-err := timex.WaitFor(ctx, func(ctx context.Context) (bool, error) {
+err := gotime.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 	return service.Ready(ctx), nil
 }, 10*time.Second, 250*time.Millisecond)
 if err != nil {
@@ -155,7 +155,7 @@ if err != nil {
 
 ```go
 for _, s := range []string{"2w", "5d", "1w2d3h"} {
-	d, _ := timex.ParseDuration(s)
+	d, _ := gotime.ParseDuration(s)
 	fmt.Printf("%s = %s\n", s, d)
 }
 

--- a/errors/asany_test.go
+++ b/errors/asany_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"testing"
 
-	pkgerrors "github.com/foomo/go/errors"
+	goerrors "github.com/foomo/go/errors"
 )
 
 func ExampleAsAny() {
@@ -19,7 +19,7 @@ func ExampleAsAny() {
 	)
 
 	_, err := os.Open("/nonexistent/path/for/example")
-	fmt.Println(pkgerrors.AsAny(err, &numErr, &pathErr))
+	fmt.Println(goerrors.AsAny(err, &numErr, &pathErr))
 	// Output: true
 }
 
@@ -79,7 +79,7 @@ func TestAsAny(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := pkgerrors.AsAny(tt.err, tt.targets()...); got != tt.want {
+			if got := goerrors.AsAny(tt.err, tt.targets()...); got != tt.want {
 				t.Errorf("AsAny() = %v, want %v", got, tt.want)
 			}
 		})
@@ -90,7 +90,7 @@ func TestAsAny(t *testing.T) {
 			numErr  *strconv.NumError
 			pathTgt *fs.PathError
 		)
-		if !pkgerrors.AsAny(pathErr, &numErr, &pathTgt) {
+		if !goerrors.AsAny(pathErr, &numErr, &pathTgt) {
 			t.Fatal("AsAny() = false, want true")
 		}
 

--- a/errors/asanytype_test.go
+++ b/errors/asanytype_test.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 	"testing"
 
-	pkgerrors "github.com/foomo/go/errors"
+	goerrors "github.com/foomo/go/errors"
 )
 
 func ExampleAsAnyType() {
 	_, err := os.Open("/nonexistent/path/for/example")
-	fmt.Println(pkgerrors.AsAnyType(err, &fs.PathError{}, &strconv.NumError{}))
+	fmt.Println(goerrors.AsAnyType(err, &fs.PathError{}, &strconv.NumError{}))
 
 	// Output: true
 }
@@ -97,7 +97,7 @@ func TestAsAnyType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := pkgerrors.AsAnyType(tt.err, tt.targets...); got != tt.want {
+			if got := goerrors.AsAnyType(tt.err, tt.targets...); got != tt.want {
 				t.Errorf("AsAnyType() = %v, want %v", got, tt.want)
 			}
 		})

--- a/errors/isany_test.go
+++ b/errors/isany_test.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"testing"
 
-	pkgerrors "github.com/foomo/go/errors"
+	goerrors "github.com/foomo/go/errors"
 )
 
 func ExampleIsAny() {
 	err := fmt.Errorf("wrapped: %w", io.EOF)
-	fmt.Println(pkgerrors.IsAny(err, context.Canceled, io.EOF))
+	fmt.Println(goerrors.IsAny(err, context.Canceled, io.EOF))
 	// Output: true
 }
 
@@ -77,7 +77,7 @@ func TestIsAny(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := pkgerrors.IsAny(tt.err, tt.targets...); got != tt.want {
+			if got := goerrors.IsAny(tt.err, tt.targets...); got != tt.want {
 				t.Errorf("IsAny() = %v, want %v", got, tt.want)
 			}
 		})

--- a/fmt/tprintf_test.go
+++ b/fmt/tprintf_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	fmtx "github.com/foomo/go/fmt"
+	gofmt "github.com/foomo/go/fmt"
 )
 
 func ExampleTprintf() {
 	format := "%{.name} is %{.age} years old"
-	fmt.Println(fmtx.Tprintf(format, "name", "John", "age", "30"))
+	fmt.Println(gofmt.Tprintf(format, "name", "John", "age", "30"))
 
 	// Output: John is 30 years old
 }
@@ -94,7 +94,7 @@ func TestTprintf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, fmtx.Tprintf(tt.format, tt.pairs...))
+			assert.Equal(t, tt.want, gofmt.Tprintf(tt.format, tt.pairs...))
 		})
 	}
 }

--- a/net/freeport_test.go
+++ b/net/freeport_test.go
@@ -5,7 +5,7 @@ import (
 	stdnet "net"
 	"testing"
 
-	netx "github.com/foomo/go/net"
+	gonet "github.com/foomo/go/net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +13,7 @@ import (
 func TestFreePort(t *testing.T) {
 	t.Parallel()
 
-	port, err := netx.FreePort(t.Context())
+	port, err := gonet.FreePort(t.Context())
 	require.NoError(t, err)
 	assert.Positive(t, port)
 }
@@ -25,7 +25,7 @@ func TestFreePort_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	port, err := netx.FreePort(ctx)
+	port, err := gonet.FreePort(ctx)
 	require.Error(t, err)
 	assert.Zero(t, port)
 }
@@ -33,7 +33,7 @@ func TestFreePort_CanceledContext(t *testing.T) {
 func TestFreePorts(t *testing.T) {
 	t.Parallel()
 
-	ports, err := netx.FreePorts(t.Context(), 3)
+	ports, err := gonet.FreePorts(t.Context(), 3)
 	require.NoError(t, err)
 	require.Len(t, ports, 3)
 
@@ -50,7 +50,7 @@ func TestFreePorts(t *testing.T) {
 func TestFreePorts_Zero(t *testing.T) {
 	t.Parallel()
 
-	ports, err := netx.FreePorts(t.Context(), 0)
+	ports, err := gonet.FreePorts(t.Context(), 0)
 	require.NoError(t, err)
 	assert.Nil(t, ports)
 }
@@ -58,7 +58,7 @@ func TestFreePorts_Zero(t *testing.T) {
 func TestFreePorts_Negative(t *testing.T) {
 	t.Parallel()
 
-	ports, err := netx.FreePorts(t.Context(), -1)
+	ports, err := gonet.FreePorts(t.Context(), -1)
 	require.NoError(t, err)
 	assert.Nil(t, ports)
 }
@@ -70,7 +70,7 @@ func TestFreePorts_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	ports, err := netx.FreePorts(ctx, 3)
+	ports, err := gonet.FreePorts(ctx, 3)
 	require.Error(t, err)
 	assert.Nil(t, ports)
 }
@@ -78,10 +78,10 @@ func TestFreePorts_CanceledContext(t *testing.T) {
 func TestIsFreePort(t *testing.T) {
 	t.Parallel()
 
-	port, err := netx.FreePort(t.Context())
+	port, err := gonet.FreePort(t.Context())
 	require.NoError(t, err)
 
-	require.NoError(t, netx.IsFreePort(t.Context(), port))
+	require.NoError(t, gonet.IsFreePort(t.Context(), port))
 }
 
 func TestIsFreePort_InUse(t *testing.T) {
@@ -93,18 +93,18 @@ func TestIsFreePort_InUse(t *testing.T) {
 
 	addr, ok := l.Addr().(*stdnet.TCPAddr)
 	require.True(t, ok)
-	require.Error(t, netx.IsFreePort(t.Context(), addr.Port))
+	require.Error(t, gonet.IsFreePort(t.Context(), addr.Port))
 }
 
 func TestIsFreePort_CanceledContext(t *testing.T) {
 	t.Skip("underlying Listen() does not support cancellation")
 	t.Parallel()
 
-	port, err := netx.FreePort(t.Context())
+	port, err := gonet.FreePort(t.Context())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	require.Error(t, netx.IsFreePort(ctx, port))
+	require.Error(t, gonet.IsFreePort(ctx, port))
 }

--- a/net/waitfor.go
+++ b/net/waitfor.go
@@ -5,12 +5,12 @@ import (
 	"net"
 	"time"
 
-	timex "github.com/foomo/go/time"
+	gotime "github.com/foomo/go/time"
 )
 
 // WaitFor attempts to establish a connection to the specified address until the timeout or context cancellation occurs.
 func WaitFor(ctx context.Context, network, address string, timeout time.Duration) error {
-	return timex.WaitFor(ctx, func(ctx context.Context) (bool, error) {
+	return gotime.WaitFor(ctx, func(ctx context.Context) (bool, error) {
 		conn, err := (&net.Dialer{Timeout: time.Second}).DialContext(ctx, network, address)
 		if err != nil {
 			return false, err

--- a/net/waitfor_test.go
+++ b/net/waitfor_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	netx "github.com/foomo/go/net"
+	gonet "github.com/foomo/go/net"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,25 +38,25 @@ func TestWaitFor(t *testing.T) {
 		<-done
 	})
 
-	require.NoError(t, netx.WaitFor(t.Context(), "tcp", l.Addr().String(), time.Second))
+	require.NoError(t, gonet.WaitFor(t.Context(), "tcp", l.Addr().String(), time.Second))
 }
 
 func TestWaitFor_Timeout(t *testing.T) {
 	t.Parallel()
 
-	port, err := netx.FreePort(t.Context())
+	port, err := gonet.FreePort(t.Context())
 	require.NoError(t, err)
 
 	addr := stdnet.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 
-	err = netx.WaitFor(t.Context(), "tcp", addr, 200*time.Millisecond)
+	err = gonet.WaitFor(t.Context(), "tcp", addr, 200*time.Millisecond)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestWaitFor_CanceledContext(t *testing.T) {
 	t.Parallel()
 
-	port, err := netx.FreePort(t.Context())
+	port, err := gonet.FreePort(t.Context())
 	require.NoError(t, err)
 
 	addr := stdnet.JoinHostPort("127.0.0.1", strconv.Itoa(port))
@@ -68,6 +68,6 @@ func TestWaitFor_CanceledContext(t *testing.T) {
 		cancel()
 	}()
 
-	err = netx.WaitFor(ctx, "tcp", addr, time.Second)
+	err = gonet.WaitFor(ctx, "tcp", addr, time.Second)
 	require.ErrorIs(t, err, context.Canceled)
 }

--- a/os/expand_test.go
+++ b/os/expand_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	osx "github.com/foomo/go/os"
+	goos "github.com/foomo/go/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +15,7 @@ func TestExpand(t *testing.T) {
 		home, err := os.UserHomeDir()
 		require.NoError(t, err)
 
-		got, err := osx.Expand("~/foo/bar")
+		got, err := goos.Expand("~/foo/bar")
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Join(home, "foo", "bar"), got)
 	})
@@ -23,13 +23,13 @@ func TestExpand(t *testing.T) {
 	t.Run("env var", func(t *testing.T) {
 		t.Setenv("EXPAND_TEST_VAR", "value")
 
-		got, err := osx.Expand("prefix-$EXPAND_TEST_VAR-${EXPAND_TEST_VAR}")
+		got, err := goos.Expand("prefix-$EXPAND_TEST_VAR-${EXPAND_TEST_VAR}")
 		require.NoError(t, err)
 		assert.Equal(t, "prefix-value-value", got)
 	})
 
 	t.Run("plain passthrough", func(t *testing.T) {
-		got, err := osx.Expand("/absolute/path")
+		got, err := goos.Expand("/absolute/path")
 		require.NoError(t, err)
 		assert.Equal(t, "/absolute/path", got)
 	})

--- a/os/getenv.go
+++ b/os/getenv.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	slicesx "github.com/foomo/go/slices"
+	goslices "github.com/foomo/go/slices"
 )
 
 var (
@@ -424,7 +424,7 @@ func getenvSlice[T any](key string, def []T, parse func(string) (T, error)) ([]T
 
 	parts := strings.Split(str, SliceSeparator)
 
-	return slicesx.MapE(parts, func(p string) (T, error) {
+	return goslices.MapE(parts, func(p string) (T, error) {
 		return parse(strings.TrimSpace(p))
 	})
 }

--- a/os/getenv_test.go
+++ b/os/getenv_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	osx "github.com/foomo/go/os"
+	goos "github.com/foomo/go/os"
 )
 
 // ---------------------------------- helpers ----------------------------------
@@ -14,11 +14,11 @@ import (
 func ExampleHasEnv() {
 	_ = os.Unsetenv("FOO")
 
-	fmt.Println(osx.HasEnv("FOO"))
+	fmt.Println(goos.HasEnv("FOO"))
 
 	_ = os.Setenv("FOO", "bar")
 
-	fmt.Println(osx.HasEnv("FOO"))
+	fmt.Println(goos.HasEnv("FOO"))
 
 	// Output:
 	// false
@@ -28,7 +28,7 @@ func ExampleHasEnv() {
 func ExampleMustHasEnv() {
 	_ = os.Setenv("FOO", "bar")
 
-	osx.MustHasEnv("FOO") // does not panic
+	goos.MustHasEnv("FOO") // does not panic
 	fmt.Println("ok")
 
 	// Output:
@@ -40,11 +40,11 @@ func ExampleMustHasEnv() {
 func ExampleGetenv() {
 	_ = os.Setenv("FOO", "")
 
-	fmt.Println(osx.Getenv("FOO", "fallback"))
+	fmt.Println(goos.Getenv("FOO", "fallback"))
 
 	_ = os.Setenv("FOO", "bar")
 
-	fmt.Println(osx.Getenv("FOO", "fallback"))
+	fmt.Println(goos.Getenv("FOO", "fallback"))
 
 	// Output:
 	// fallback
@@ -53,11 +53,11 @@ func ExampleGetenv() {
 
 func ExampleGetenvBool() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvBool("FOO", false)
+	v, _ := goos.GetenvBool("FOO", false)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "true")
-	v, _ = osx.GetenvBool("FOO", false)
+	v, _ = goos.GetenvBool("FOO", false)
 	fmt.Println(v)
 
 	// Output:
@@ -67,11 +67,11 @@ func ExampleGetenvBool() {
 
 func ExampleGetenvInt() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvInt("FOO", 1)
+	v, _ := goos.GetenvInt("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "42")
-	v, _ = osx.GetenvInt("FOO", 1)
+	v, _ = goos.GetenvInt("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -81,15 +81,15 @@ func ExampleGetenvInt() {
 
 func ExampleGetenvInt8() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvInt8("FOO", 1)
+	v, _ := goos.GetenvInt8("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "127")
-	v, _ = osx.GetenvInt8("FOO", 1)
+	v, _ = goos.GetenvInt8("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "128")
-	_, err := osx.GetenvInt8("FOO", 0)
+	_, err := goos.GetenvInt8("FOO", 0)
 	fmt.Println(err != nil)
 
 	// Output:
@@ -100,11 +100,11 @@ func ExampleGetenvInt8() {
 
 func ExampleGetenvInt16() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvInt16("FOO", 1)
+	v, _ := goos.GetenvInt16("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "1000")
-	v, _ = osx.GetenvInt16("FOO", 1)
+	v, _ = goos.GetenvInt16("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -114,19 +114,19 @@ func ExampleGetenvInt16() {
 
 func ExampleGetenvInt32() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvInt32("FOO", 1)
+	v, _ := goos.GetenvInt32("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "2")
-	v, _ = osx.GetenvInt32("FOO", 1)
+	v, _ = goos.GetenvInt32("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "0x1F")
-	v, _ = osx.GetenvInt32("FOO", 0)
+	v, _ = goos.GetenvInt32("FOO", 0)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "2147483648")
-	_, err := osx.GetenvInt32("FOO", 0)
+	_, err := goos.GetenvInt32("FOO", 0)
 	fmt.Println(err != nil)
 
 	// Output:
@@ -138,11 +138,11 @@ func ExampleGetenvInt32() {
 
 func ExampleGetenvInt64() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvInt64("FOO", 1)
+	v, _ := goos.GetenvInt64("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "2")
-	v, _ = osx.GetenvInt64("FOO", 1)
+	v, _ = goos.GetenvInt64("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -152,11 +152,11 @@ func ExampleGetenvInt64() {
 
 func ExampleGetenvUint() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvUint("FOO", 1)
+	v, _ := goos.GetenvUint("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "42")
-	v, _ = osx.GetenvUint("FOO", 1)
+	v, _ = goos.GetenvUint("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -166,15 +166,15 @@ func ExampleGetenvUint() {
 
 func ExampleGetenvUint8() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvUint8("FOO", 1)
+	v, _ := goos.GetenvUint8("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "255")
-	v, _ = osx.GetenvUint8("FOO", 1)
+	v, _ = goos.GetenvUint8("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "256")
-	_, err := osx.GetenvUint8("FOO", 0)
+	_, err := goos.GetenvUint8("FOO", 0)
 	fmt.Println(err != nil)
 
 	// Output:
@@ -185,11 +185,11 @@ func ExampleGetenvUint8() {
 
 func ExampleGetenvUint16() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvUint16("FOO", 1)
+	v, _ := goos.GetenvUint16("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "65535")
-	v, _ = osx.GetenvUint16("FOO", 1)
+	v, _ = goos.GetenvUint16("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -199,11 +199,11 @@ func ExampleGetenvUint16() {
 
 func ExampleGetenvUint32() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvUint32("FOO", 1)
+	v, _ := goos.GetenvUint32("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "100000")
-	v, _ = osx.GetenvUint32("FOO", 1)
+	v, _ = goos.GetenvUint32("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -213,11 +213,11 @@ func ExampleGetenvUint32() {
 
 func ExampleGetenvUint64() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvUint64("FOO", 1)
+	v, _ := goos.GetenvUint64("FOO", 1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "18446744073709551615")
-	v, _ = osx.GetenvUint64("FOO", 1)
+	v, _ = goos.GetenvUint64("FOO", 1)
 	fmt.Println(v)
 
 	// Output:
@@ -227,15 +227,15 @@ func ExampleGetenvUint64() {
 
 func ExampleGetenvFloat32() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvFloat32("FOO", 0.5)
+	v, _ := goos.GetenvFloat32("FOO", 0.5)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "1.5")
-	v, _ = osx.GetenvFloat32("FOO", 0.5)
+	v, _ = goos.GetenvFloat32("FOO", 0.5)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "not-a-number")
-	_, err := osx.GetenvFloat32("FOO", 0)
+	_, err := goos.GetenvFloat32("FOO", 0)
 	fmt.Println(err != nil)
 
 	// Output:
@@ -246,11 +246,11 @@ func ExampleGetenvFloat32() {
 
 func ExampleGetenvFloat64() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvFloat64("FOO", 0.1)
+	v, _ := goos.GetenvFloat64("FOO", 0.1)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "0.2")
-	v, _ = osx.GetenvFloat64("FOO", 0.1)
+	v, _ = goos.GetenvFloat64("FOO", 0.1)
 	fmt.Println(v)
 
 	// Output:
@@ -260,15 +260,15 @@ func ExampleGetenvFloat64() {
 
 func ExampleGetenvDuration() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvDuration("FOO", 5*time.Second)
+	v, _ := goos.GetenvDuration("FOO", 5*time.Second)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "100ms")
-	v, _ = osx.GetenvDuration("FOO", 5*time.Second)
+	v, _ = goos.GetenvDuration("FOO", 5*time.Second)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "invalid")
-	_, err := osx.GetenvDuration("FOO", 0)
+	_, err := goos.GetenvDuration("FOO", 0)
 	fmt.Println(err != nil)
 
 	// Output:
@@ -282,7 +282,7 @@ func ExampleGetenvDuration() {
 func ExampleMustGetenv() {
 	_ = os.Setenv("FOO", "bar")
 
-	fmt.Println(osx.MustGetenv("FOO"))
+	fmt.Println(goos.MustGetenv("FOO"))
 
 	// Output:
 	// bar
@@ -291,7 +291,7 @@ func ExampleMustGetenv() {
 func ExampleMustGetenvBool() {
 	_ = os.Setenv("FOO", "true")
 
-	fmt.Println(osx.MustGetenvBool("FOO"))
+	fmt.Println(goos.MustGetenvBool("FOO"))
 
 	// Output:
 	// true
@@ -300,7 +300,7 @@ func ExampleMustGetenvBool() {
 func ExampleMustGetenvInt() {
 	_ = os.Setenv("FOO", "42")
 
-	fmt.Println(osx.MustGetenvInt("FOO"))
+	fmt.Println(goos.MustGetenvInt("FOO"))
 
 	// Output:
 	// 42
@@ -309,7 +309,7 @@ func ExampleMustGetenvInt() {
 func ExampleMustGetenvInt8() {
 	_ = os.Setenv("FOO", "127")
 
-	fmt.Println(osx.MustGetenvInt8("FOO"))
+	fmt.Println(goos.MustGetenvInt8("FOO"))
 
 	// Output:
 	// 127
@@ -318,7 +318,7 @@ func ExampleMustGetenvInt8() {
 func ExampleMustGetenvInt16() {
 	_ = os.Setenv("FOO", "1000")
 
-	fmt.Println(osx.MustGetenvInt16("FOO"))
+	fmt.Println(goos.MustGetenvInt16("FOO"))
 
 	// Output:
 	// 1000
@@ -327,7 +327,7 @@ func ExampleMustGetenvInt16() {
 func ExampleMustGetenvInt32() {
 	_ = os.Setenv("FOO", "100000")
 
-	fmt.Println(osx.MustGetenvInt32("FOO"))
+	fmt.Println(goos.MustGetenvInt32("FOO"))
 
 	// Output:
 	// 100000
@@ -336,7 +336,7 @@ func ExampleMustGetenvInt32() {
 func ExampleMustGetenvInt64() {
 	_ = os.Setenv("FOO", "100000")
 
-	fmt.Println(osx.MustGetenvInt64("FOO"))
+	fmt.Println(goos.MustGetenvInt64("FOO"))
 
 	// Output:
 	// 100000
@@ -345,7 +345,7 @@ func ExampleMustGetenvInt64() {
 func ExampleMustGetenvUint() {
 	_ = os.Setenv("FOO", "42")
 
-	fmt.Println(osx.MustGetenvUint("FOO"))
+	fmt.Println(goos.MustGetenvUint("FOO"))
 
 	// Output:
 	// 42
@@ -354,7 +354,7 @@ func ExampleMustGetenvUint() {
 func ExampleMustGetenvUint8() {
 	_ = os.Setenv("FOO", "255")
 
-	fmt.Println(osx.MustGetenvUint8("FOO"))
+	fmt.Println(goos.MustGetenvUint8("FOO"))
 
 	// Output:
 	// 255
@@ -363,7 +363,7 @@ func ExampleMustGetenvUint8() {
 func ExampleMustGetenvUint16() {
 	_ = os.Setenv("FOO", "65535")
 
-	fmt.Println(osx.MustGetenvUint16("FOO"))
+	fmt.Println(goos.MustGetenvUint16("FOO"))
 
 	// Output:
 	// 65535
@@ -372,7 +372,7 @@ func ExampleMustGetenvUint16() {
 func ExampleMustGetenvUint32() {
 	_ = os.Setenv("FOO", "100000")
 
-	fmt.Println(osx.MustGetenvUint32("FOO"))
+	fmt.Println(goos.MustGetenvUint32("FOO"))
 
 	// Output:
 	// 100000
@@ -381,7 +381,7 @@ func ExampleMustGetenvUint32() {
 func ExampleMustGetenvUint64() {
 	_ = os.Setenv("FOO", "18446744073709551615")
 
-	fmt.Println(osx.MustGetenvUint64("FOO"))
+	fmt.Println(goos.MustGetenvUint64("FOO"))
 
 	// Output:
 	// 18446744073709551615
@@ -390,7 +390,7 @@ func ExampleMustGetenvUint64() {
 func ExampleMustGetenvFloat32() {
 	_ = os.Setenv("FOO", "1.5")
 
-	fmt.Println(osx.MustGetenvFloat32("FOO"))
+	fmt.Println(goos.MustGetenvFloat32("FOO"))
 
 	// Output:
 	// 1.5
@@ -399,7 +399,7 @@ func ExampleMustGetenvFloat32() {
 func ExampleMustGetenvFloat64() {
 	_ = os.Setenv("FOO", "3.14")
 
-	fmt.Println(osx.MustGetenvFloat64("FOO"))
+	fmt.Println(goos.MustGetenvFloat64("FOO"))
 
 	// Output:
 	// 3.14
@@ -408,7 +408,7 @@ func ExampleMustGetenvFloat64() {
 func ExampleMustGetenvDuration() {
 	_ = os.Setenv("FOO", "5s")
 
-	fmt.Println(osx.MustGetenvDuration("FOO"))
+	fmt.Println(goos.MustGetenvDuration("FOO"))
 
 	// Output:
 	// 5s
@@ -419,15 +419,15 @@ func ExampleMustGetenvDuration() {
 func ExampleGetenvStringSlice() {
 	_ = os.Setenv("FOO", "")
 
-	fmt.Println(osx.GetenvStringSlice("FOO", nil))
+	fmt.Println(goos.GetenvStringSlice("FOO", nil))
 
 	_ = os.Setenv("FOO", "foo")
 
-	fmt.Println(osx.GetenvStringSlice("FOO", nil))
+	fmt.Println(goos.GetenvStringSlice("FOO", nil))
 
 	_ = os.Setenv("FOO", "foo,bar")
 
-	fmt.Println(osx.GetenvStringSlice("FOO", nil))
+	fmt.Println(goos.GetenvStringSlice("FOO", nil))
 
 	// Output:
 	// []
@@ -437,11 +437,11 @@ func ExampleGetenvStringSlice() {
 
 func ExampleGetenvBoolSlice() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvBoolSlice("FOO", nil)
+	v, _ := goos.GetenvBoolSlice("FOO", nil)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "true,false,true")
-	v, _ = osx.GetenvBoolSlice("FOO", nil)
+	v, _ = goos.GetenvBoolSlice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -451,11 +451,11 @@ func ExampleGetenvBoolSlice() {
 
 func ExampleGetenvIntSlice() {
 	_ = os.Setenv("FOO", "")
-	v, _ := osx.GetenvIntSlice("FOO", nil)
+	v, _ := goos.GetenvIntSlice("FOO", nil)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ = osx.GetenvIntSlice("FOO", nil)
+	v, _ = goos.GetenvIntSlice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -465,7 +465,7 @@ func ExampleGetenvIntSlice() {
 
 func ExampleGetenvInt8Slice() {
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ := osx.GetenvInt8Slice("FOO", nil)
+	v, _ := goos.GetenvInt8Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -474,7 +474,7 @@ func ExampleGetenvInt8Slice() {
 
 func ExampleGetenvInt16Slice() {
 	_ = os.Setenv("FOO", "100, 200, 300")
-	v, _ := osx.GetenvInt16Slice("FOO", nil)
+	v, _ := goos.GetenvInt16Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -483,7 +483,7 @@ func ExampleGetenvInt16Slice() {
 
 func ExampleGetenvInt32Slice() {
 	_ = os.Setenv("FOO", "100, 200, 300")
-	v, _ := osx.GetenvInt32Slice("FOO", nil)
+	v, _ := goos.GetenvInt32Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -492,7 +492,7 @@ func ExampleGetenvInt32Slice() {
 
 func ExampleGetenvInt64Slice() {
 	_ = os.Setenv("FOO", "100, 200, 300")
-	v, _ := osx.GetenvInt64Slice("FOO", nil)
+	v, _ := goos.GetenvInt64Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -501,7 +501,7 @@ func ExampleGetenvInt64Slice() {
 
 func ExampleGetenvUintSlice() {
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ := osx.GetenvUintSlice("FOO", nil)
+	v, _ := goos.GetenvUintSlice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -510,7 +510,7 @@ func ExampleGetenvUintSlice() {
 
 func ExampleGetenvUint8Slice() {
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ := osx.GetenvUint8Slice("FOO", nil)
+	v, _ := goos.GetenvUint8Slice("FOO", nil)
 	fmt.Println(v) //nolint:staticcheck // QF1010
 
 	// Output:
@@ -519,7 +519,7 @@ func ExampleGetenvUint8Slice() {
 
 func ExampleGetenvUint16Slice() {
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ := osx.GetenvUint16Slice("FOO", nil)
+	v, _ := goos.GetenvUint16Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -528,7 +528,7 @@ func ExampleGetenvUint16Slice() {
 
 func ExampleGetenvUint32Slice() {
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ := osx.GetenvUint32Slice("FOO", nil)
+	v, _ := goos.GetenvUint32Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -537,7 +537,7 @@ func ExampleGetenvUint32Slice() {
 
 func ExampleGetenvUint64Slice() {
 	_ = os.Setenv("FOO", "1, 2, 3")
-	v, _ := osx.GetenvUint64Slice("FOO", nil)
+	v, _ := goos.GetenvUint64Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -546,7 +546,7 @@ func ExampleGetenvUint64Slice() {
 
 func ExampleGetenvFloat32Slice() {
 	_ = os.Setenv("FOO", "1.1, 2.2, 3.3")
-	v, _ := osx.GetenvFloat32Slice("FOO", nil)
+	v, _ := goos.GetenvFloat32Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -555,7 +555,7 @@ func ExampleGetenvFloat32Slice() {
 
 func ExampleGetenvFloat64Slice() {
 	_ = os.Setenv("FOO", "1.1, 2.2, 3.3")
-	v, _ := osx.GetenvFloat64Slice("FOO", nil)
+	v, _ := goos.GetenvFloat64Slice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -564,7 +564,7 @@ func ExampleGetenvFloat64Slice() {
 
 func ExampleGetenvDurationSlice() {
 	_ = os.Setenv("FOO", "1s, 500ms, 2m")
-	v, _ := osx.GetenvDurationSlice("FOO", nil)
+	v, _ := goos.GetenvDurationSlice("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -575,11 +575,11 @@ func ExampleGetenvDurationSlice() {
 
 func ExampleGetenvStringMap() {
 	_ = os.Setenv("FOO", "a:1")
-	v, _ := osx.GetenvStringMap("FOO", nil)
+	v, _ := goos.GetenvStringMap("FOO", nil)
 	fmt.Println(v)
 
 	_ = os.Setenv("FOO", " x : hello , y : world ")
-	v, _ = osx.GetenvStringMap("FOO", nil)
+	v, _ = goos.GetenvStringMap("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -593,7 +593,7 @@ func ExampleGetenvStringMap() {
 	}
 
 	_ = os.Setenv("FOO", "invalid")
-	_, err := osx.GetenvStringMap("FOO", nil)
+	_, err := goos.GetenvStringMap("FOO", nil)
 	fmt.Println(err != nil)
 
 	// Output:
@@ -605,7 +605,7 @@ func ExampleGetenvStringMap() {
 
 func ExampleGetenvStringMapString() {
 	_ = os.Setenv("FOO", "a:1")
-	v, _ := osx.GetenvStringMapString("FOO", nil)
+	v, _ := goos.GetenvStringMapString("FOO", nil)
 	fmt.Println(v)
 
 	// Output:
@@ -614,7 +614,7 @@ func ExampleGetenvStringMapString() {
 
 func ExampleGetenvBoolMap() {
 	_ = os.Setenv("FOO", "debug:true, verbose:false")
-	v, _ := osx.GetenvBoolMap("FOO", nil)
+	v, _ := goos.GetenvBoolMap("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -634,7 +634,7 @@ func ExampleGetenvBoolMap() {
 
 func ExampleGetenvIntMap() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvIntMap("FOO", nil)
+	v, _ := goos.GetenvIntMap("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -654,7 +654,7 @@ func ExampleGetenvIntMap() {
 
 func ExampleGetenvInt8Map() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvInt8Map("FOO", nil)
+	v, _ := goos.GetenvInt8Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -674,7 +674,7 @@ func ExampleGetenvInt8Map() {
 
 func ExampleGetenvInt16Map() {
 	_ = os.Setenv("FOO", "a:100, b:200")
-	v, _ := osx.GetenvInt16Map("FOO", nil)
+	v, _ := goos.GetenvInt16Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -694,7 +694,7 @@ func ExampleGetenvInt16Map() {
 
 func ExampleGetenvInt32Map() {
 	_ = os.Setenv("FOO", "a:100, b:200")
-	v, _ := osx.GetenvInt32Map("FOO", nil)
+	v, _ := goos.GetenvInt32Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -714,7 +714,7 @@ func ExampleGetenvInt32Map() {
 
 func ExampleGetenvInt64Map() {
 	_ = os.Setenv("FOO", "a:100, b:200")
-	v, _ := osx.GetenvInt64Map("FOO", nil)
+	v, _ := goos.GetenvInt64Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -734,7 +734,7 @@ func ExampleGetenvInt64Map() {
 
 func ExampleGetenvUintMap() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvUintMap("FOO", nil)
+	v, _ := goos.GetenvUintMap("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -754,7 +754,7 @@ func ExampleGetenvUintMap() {
 
 func ExampleGetenvUint8Map() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvUint8Map("FOO", nil)
+	v, _ := goos.GetenvUint8Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -774,7 +774,7 @@ func ExampleGetenvUint8Map() {
 
 func ExampleGetenvUint16Map() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvUint16Map("FOO", nil)
+	v, _ := goos.GetenvUint16Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -794,7 +794,7 @@ func ExampleGetenvUint16Map() {
 
 func ExampleGetenvUint32Map() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvUint32Map("FOO", nil)
+	v, _ := goos.GetenvUint32Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -814,7 +814,7 @@ func ExampleGetenvUint32Map() {
 
 func ExampleGetenvUint64Map() {
 	_ = os.Setenv("FOO", "a:1, b:2")
-	v, _ := osx.GetenvUint64Map("FOO", nil)
+	v, _ := goos.GetenvUint64Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -834,7 +834,7 @@ func ExampleGetenvUint64Map() {
 
 func ExampleGetenvFloat32Map() {
 	_ = os.Setenv("FOO", "a:1.5, b:2.5")
-	v, _ := osx.GetenvFloat32Map("FOO", nil)
+	v, _ := goos.GetenvFloat32Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -854,7 +854,7 @@ func ExampleGetenvFloat32Map() {
 
 func ExampleGetenvFloat64Map() {
 	_ = os.Setenv("FOO", "a:1.5, b:2.5")
-	v, _ := osx.GetenvFloat64Map("FOO", nil)
+	v, _ := goos.GetenvFloat64Map("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {
@@ -874,7 +874,7 @@ func ExampleGetenvFloat64Map() {
 
 func ExampleGetenvDurationMap() {
 	_ = os.Setenv("FOO", "timeout:5s, interval:100ms")
-	v, _ := osx.GetenvDurationMap("FOO", nil)
+	v, _ := goos.GetenvDurationMap("FOO", nil)
 
 	keys := make([]string, 0, len(v))
 	for k := range v {

--- a/slog/testhandler_test.go
+++ b/slog/testhandler_test.go
@@ -4,12 +4,12 @@ import (
 	"log/slog"
 	"testing"
 
-	slogx "github.com/foomo/go/slog"
+	goslog "github.com/foomo/go/slog"
 )
 
 func TestNewTestHandler(t *testing.T) {
 	t.Run("default options", func(t *testing.T) {
-		l := slog.New(slogx.NewTestHandler(t))
+		l := slog.New(goslog.NewTestHandler(t))
 		l.Debug("debug message", "key", "value")
 		l.Info("info message", "key", "value")
 		l.Warn("warn message", "key", "value")
@@ -17,7 +17,7 @@ func TestNewTestHandler(t *testing.T) {
 	})
 
 	t.Run("custom level", func(t *testing.T) {
-		l := slog.New(slogx.NewTestHandler(t, slogx.TestHandlerWithLevel(slog.LevelWarn)))
+		l := slog.New(goslog.NewTestHandler(t, goslog.TestHandlerWithLevel(slog.LevelWarn)))
 		l.Debug("should be filtered")
 		l.Info("should be filtered")
 		l.Warn("should appear", "key", "value")
@@ -25,17 +25,17 @@ func TestNewTestHandler(t *testing.T) {
 	})
 
 	t.Run("with group and attrs", func(t *testing.T) {
-		l := slog.New(slogx.NewTestHandler(t))
+		l := slog.New(goslog.NewTestHandler(t))
 		l.WithGroup("request").With("method", "GET").Info("handled")
 	})
 
 	t.Run("nested groups", func(t *testing.T) {
-		l := slog.New(slogx.NewTestHandler(t))
+		l := slog.New(goslog.NewTestHandler(t))
 		l.WithGroup("http").WithGroup("request").Info("handled", "path", "/api")
 	})
 
 	t.Run("inline group attr", func(t *testing.T) {
-		l := slog.New(slogx.NewTestHandler(t))
+		l := slog.New(goslog.NewTestHandler(t))
 		l.Info("handled", slog.Group("request", "method", "GET", "path", "/api"))
 	})
 }

--- a/slog/withgroup_test.go
+++ b/slog/withgroup_test.go
@@ -4,14 +4,14 @@ import (
 	"log/slog"
 	"testing"
 
-	slogx "github.com/foomo/go/slog"
+	goslog "github.com/foomo/go/slog"
 )
 
 // TestWithGroupEmpty covers the empty-name short-circuit in WithGroup.
 // slog.Logger.WithGroup("") short-circuits in stdlib and never reaches the
 // handler, so call the handler directly.
 func TestWithGroupEmpty(t *testing.T) {
-	h := slogx.NewTestHandler(t)
+	h := goslog.NewTestHandler(t)
 	if got := h.WithGroup(""); got != h {
 		t.Error("WithGroup(\"\") should return the same handler")
 	}

--- a/strings/compose_test.go
+++ b/strings/compose_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	stringsx "github.com/foomo/go/strings"
+	gostrings "github.com/foomo/go/strings"
 )
 
 func ExampleCompose() {
-	result := stringsx.Compose("HELLO", strings.ToLower, stringsx.FirstToUpper)
+	result := gostrings.Compose("HELLO", strings.ToLower, gostrings.FirstToUpper)
 	fmt.Println(result)
 	// Output: Hello
 }

--- a/testing/ed25519_test.go
+++ b/testing/ed25519_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	testingx "github.com/foomo/go/testing"
+	gotesting "github.com/foomo/go/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +16,7 @@ import (
 func TestGenerateED25519KeyPair(t *testing.T) {
 	t.Parallel()
 
-	publicPath, privatePath := testingx.GenerateED25519KeyPair(t)
+	publicPath, privatePath := gotesting.GenerateED25519KeyPair(t)
 
 	require.FileExists(t, publicPath)
 	require.FileExists(t, privatePath)
@@ -45,9 +45,9 @@ func TestGenerateED25519KeyPair(t *testing.T) {
 func TestEncodeED25519Keys(t *testing.T) {
 	t.Parallel()
 
-	privateKey := testingx.GenerateED25519PrivateKey(t)
+	privateKey := gotesting.GenerateED25519PrivateKey(t)
 
-	privatePEM := testingx.EncodeED25519PrivateKey(t, privateKey)
+	privatePEM := gotesting.EncodeED25519PrivateKey(t, privateKey)
 	block, _ := pem.Decode([]byte(privatePEM))
 	require.NotNil(t, block)
 	assert.Equal(t, "PRIVATE KEY", block.Type)
@@ -55,7 +55,7 @@ func TestEncodeED25519Keys(t *testing.T) {
 	publicKey, ok := privateKey.Public().(ed25519.PublicKey)
 	require.True(t, ok)
 
-	publicPEM := testingx.EncodeED25519PublicKey(t, publicKey)
+	publicPEM := gotesting.EncodeED25519PublicKey(t, publicKey)
 	block, _ = pem.Decode([]byte(publicPEM))
 	require.NotNil(t, block)
 	assert.Equal(t, "PUBLIC KEY", block.Type)
@@ -64,10 +64,10 @@ func TestEncodeED25519Keys(t *testing.T) {
 func TestGenerateED25519PublicKey(t *testing.T) {
 	t.Parallel()
 
-	privateKey := testingx.GenerateED25519PrivateKey(t)
+	privateKey := gotesting.GenerateED25519PrivateKey(t)
 	path := filepath.Join(t.TempDir(), "id_ed25519.pub")
 
-	testingx.GenerateED25519PublicKey(t, privateKey, path)
+	gotesting.GenerateED25519PublicKey(t, privateKey, path)
 
 	require.FileExists(t, path)
 

--- a/testing/exampletb_test.go
+++ b/testing/exampletb_test.go
@@ -3,7 +3,7 @@ package testing_test
 import (
 	"testing"
 
-	testingx "github.com/foomo/go/testing"
+	gotesting "github.com/foomo/go/testing"
 )
 
 func helper(tb testing.TB) {
@@ -15,7 +15,7 @@ func helper(tb testing.TB) {
 }
 
 func ExampleNewExampleTB() {
-	tb := testingx.NewExampleTB()
+	tb := gotesting.NewExampleTB()
 	helper(tb)
 
 	// Output:

--- a/testing/rsa_test.go
+++ b/testing/rsa_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	testingx "github.com/foomo/go/testing"
+	gotesting "github.com/foomo/go/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +14,7 @@ import (
 func TestGenerateRSAKeyPair(t *testing.T) {
 	t.Parallel()
 
-	publicPath, privatePath := testingx.GenerateRSAKeyPair(t)
+	publicPath, privatePath := gotesting.GenerateRSAKeyPair(t)
 
 	// verify files exist
 	require.FileExists(t, publicPath)

--- a/testing/tags.go
+++ b/testing/tags.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	osx "github.com/foomo/go/os"
+	goos "github.com/foomo/go/os"
 	tagx "github.com/foomo/go/testing/tag"
 )
 
@@ -51,7 +51,7 @@ func SkipTags(tags ...tagx.Tag) bool {
 		return true
 	}
 
-	envTags := osx.GetenvStringSlice(EnvTestTags, nil)
+	envTags := goos.GetenvStringSlice(EnvTestTags, nil)
 	// always return false if there are non tags defined
 	if envTags == nil {
 		return false

--- a/testing/tags_test.go
+++ b/testing/tags_test.go
@@ -3,7 +3,7 @@ package testing_test
 import (
 	"testing"
 
-	testingx "github.com/foomo/go/testing"
+	gotesting "github.com/foomo/go/testing"
 	tagx "github.com/foomo/go/testing/tag"
 	"github.com/stretchr/testify/assert"
 )
@@ -92,10 +92,10 @@ func TestSkipTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != "" {
-				t.Setenv(testingx.EnvTestTags, tt.env)
+				t.Setenv(gotesting.EnvTestTags, tt.env)
 			}
 
-			assert.Equalf(t, tt.want, testingx.SkipTags(tt.tags...), "skipTags(%v)", tt.tags)
+			assert.Equalf(t, tt.want, gotesting.SkipTags(tt.tags...), "skipTags(%v)", tt.tags)
 		})
 	}
 }

--- a/testing/waitfor_test.go
+++ b/testing/waitfor_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	testingx "github.com/foomo/go/testing"
+	gotesting "github.com/foomo/go/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,20 +20,20 @@ func TestWaitFor(t *testing.T) {
 		ready.Store(true)
 	}()
 
-	testingx.WaitFor(t, time.Second, ready.Load)
+	gotesting.WaitFor(t, time.Second, ready.Load)
 	require.True(t, ready.Load())
 }
 
 func TestWaitFor_Timeout(t *testing.T) {
 	t.Parallel()
 
-	tb := testingx.NewExampleTB()
-	testingx.WaitFor(tb, 50*time.Millisecond, func() bool { return false })
+	tb := gotesting.NewExampleTB()
+	gotesting.WaitFor(tb, 50*time.Millisecond, func() bool { return false })
 	require.True(t, tb.Failed())
 }
 
 func ExampleWaitFor() {
-	tb := testingx.NewExampleTB()
+	tb := gotesting.NewExampleTB()
 
 	var ready atomic.Bool
 
@@ -42,7 +42,7 @@ func ExampleWaitFor() {
 		ready.Store(true)
 	}()
 
-	testingx.WaitFor(tb, time.Second, ready.Load)
+	gotesting.WaitFor(tb, time.Second, ready.Load)
 	fmt.Println("ready:", ready.Load())
 	// Output: ready: true
 }

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	timex "github.com/foomo/go/time"
+	gotime "github.com/foomo/go/time"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,26 +16,26 @@ import (
 func restore(t *testing.T) {
 	t.Helper()
 
-	now := timex.Now
-	static := timex.NowStaticNSec
-	incremental := timex.NowIncrementalNSec
+	now := gotime.Now
+	static := gotime.NowStaticNSec
+	incremental := gotime.NowIncrementalNSec
 
 	t.Cleanup(func() {
-		timex.Now = now
-		timex.NowStaticNSec = static
-		timex.NowIncrementalNSec = incremental
+		gotime.Now = now
+		gotime.NowStaticNSec = static
+		gotime.NowIncrementalNSec = incremental
 	})
 }
 
 func TestStatic(t *testing.T) {
 	restore(t)
 
-	timex.Static()
+	gotime.Static()
 
-	want := time.Unix(0, timex.NowStaticNSec)
+	want := time.Unix(0, gotime.NowStaticNSec)
 
-	first := timex.Now()
-	second := timex.Now()
+	first := gotime.Now()
+	second := gotime.Now()
 
 	assert.Equal(t, want, first)
 	// Every call returns the very same instant.
@@ -45,12 +45,12 @@ func TestStatic(t *testing.T) {
 func TestIncremental(t *testing.T) {
 	restore(t)
 
-	timex.Incremental()
+	gotime.Incremental()
 
-	first := timex.Now()
-	require.Equal(t, time.Unix(0, timex.NowStaticNSec), first)
+	first := gotime.Now()
+	require.Equal(t, time.Unix(0, gotime.NowStaticNSec), first)
 
-	second := timex.Now()
+	second := gotime.Now()
 	// Strictly increasing by one nanosecond per call.
 	assert.Equal(t, first.Add(time.Nanosecond), second)
 	assert.True(t, second.After(first))
@@ -59,30 +59,30 @@ func TestIncremental(t *testing.T) {
 func TestResetIncremental(t *testing.T) {
 	restore(t)
 
-	timex.Incremental()
-	timex.Now()
-	timex.Now()
-	require.Greater(t, timex.NowIncrementalNSec, timex.NowStaticNSec)
+	gotime.Incremental()
+	gotime.Now()
+	gotime.Now()
+	require.Greater(t, gotime.NowIncrementalNSec, gotime.NowStaticNSec)
 
-	timex.ResetIncremental()
-	assert.Equal(t, timex.NowStaticNSec, timex.NowIncrementalNSec)
+	gotime.ResetIncremental()
+	assert.Equal(t, gotime.NowStaticNSec, gotime.NowIncrementalNSec)
 }
 
 func TestNowDefault(t *testing.T) {
 	restore(t)
 
 	// The default provider is a live clock.
-	assert.WithinDuration(t, time.Now(), timex.Now(), time.Minute)
+	assert.WithinDuration(t, time.Now(), gotime.Now(), time.Minute)
 }
 
 func ExampleStatic() {
 	// Save and restore the default clock so the example is self-contained.
-	defer func() { timex.Now = time.Now }()
+	defer func() { gotime.Now = time.Now }()
 
-	timex.Static()
+	gotime.Static()
 
-	fmt.Println(timex.Now().UTC().Format(time.RFC3339))
-	fmt.Println(timex.Now().UTC().Format(time.RFC3339))
+	fmt.Println(gotime.Now().UTC().Format(time.RFC3339))
+	fmt.Println(gotime.Now().UTC().Format(time.RFC3339))
 
 	// Output:
 	// 2021-01-01T11:00:00Z

--- a/time/waitfor_test.go
+++ b/time/waitfor_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	timex "github.com/foomo/go/time"
+	gotime "github.com/foomo/go/time"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func TestWaitFor(t *testing.T) {
 	t.Run("success on first poll", func(t *testing.T) {
 		t.Parallel()
 
-		require.NoError(t, timex.WaitFor(t.Context(), func(context.Context) (bool, error) {
+		require.NoError(t, gotime.WaitFor(t.Context(), func(context.Context) (bool, error) {
 			return true, nil
 		}, time.Second, 10*time.Millisecond))
 	})
@@ -26,7 +26,7 @@ func TestWaitFor(t *testing.T) {
 		t.Parallel()
 
 		errBoom := errors.New("boom")
-		err := timex.WaitFor(t.Context(), func(context.Context) (bool, error) {
+		err := gotime.WaitFor(t.Context(), func(context.Context) (bool, error) {
 			return true, errBoom
 		}, time.Second, 10*time.Millisecond)
 		require.ErrorIs(t, err, errBoom)
@@ -37,7 +37,7 @@ func TestWaitFor(t *testing.T) {
 
 		calls := 0
 
-		require.NoError(t, timex.WaitFor(t.Context(), func(context.Context) (bool, error) {
+		require.NoError(t, gotime.WaitFor(t.Context(), func(context.Context) (bool, error) {
 			calls++
 			return calls >= 3, nil
 		}, time.Second, 5*time.Millisecond))
@@ -47,7 +47,7 @@ func TestWaitFor(t *testing.T) {
 	t.Run("timeout", func(t *testing.T) {
 		t.Parallel()
 
-		err := timex.WaitFor(t.Context(), func(context.Context) (bool, error) {
+		err := gotime.WaitFor(t.Context(), func(context.Context) (bool, error) {
 			return false, nil
 		}, 100*time.Millisecond, 10*time.Millisecond)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
@@ -59,7 +59,7 @@ func TestWaitFor(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
-		err := timex.WaitFor(ctx, func(context.Context) (bool, error) {
+		err := gotime.WaitFor(ctx, func(context.Context) (bool, error) {
 			return false, nil
 		}, time.Second, 10*time.Millisecond)
 		require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
### Description

Migrate internal import aliases from `x`-suffix to `go`-prefix convention, enforced by a new `importas` linter rule.

### Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [x] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- Add `importas` rule to `.golangci.yaml`: `github.com/foomo/go/<pkg>` → alias `go<pkg>`
- Rename aliases across source + tests: `fmtx`→`gofmt`, `netx`→`gonet`, `osx`→`goos`, `timex`→`gotime`, `slicesx`→`goslices`, etc.
- Update `docs/*.md`, `docs/index.md`, `CLAUDE.md` to the `go`-prefix convention
- `tagx` (`testing/tag`) left unchanged — two-segment path, not matched by the rule

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
